### PR TITLE
fix: harden API retries and streamed downloads

### DIFF
--- a/Comfly.py
+++ b/Comfly.py
@@ -31,6 +31,10 @@ import inspect
 from .utils import pil2tensor, tensor2pil
 from .config_store import read_project_config, write_project_config
 from .media_download import download_image_with_retry
+from .t8star_http import (
+    create_alternating_route_session,
+    create_t8star_session,
+)
 from comfy.utils import common_upscale
 from comfy.comfy_types import IO
 from typing import Optional, Any
@@ -41,6 +45,8 @@ from comfy_api.input_impl import VideoFromFile
 from comfy_api.util import VideoComponents
 from comfy_api.input_impl import VideoFromComponents
 from fractions import Fraction
+
+
 from .fal_batch_nodes import (
     Comfly_ideogram_v4_fal,
     Comfly_mai_image_2_5_fal,
@@ -109,6 +115,24 @@ from .seedance_low_price_nodes import (
     Comfly_suno_music_lowprice,
 )
 from .midjourney_low_price_nodes import Comfly_midjourney_lowprice
+
+
+RESULT_DOWNLOAD_ATTEMPTS = 4
+
+
+def _rewind_multipart_files(value):
+    """Reset file-like multipart values before a submit retry."""
+    if hasattr(value, "seek"):
+        value.seek(0)
+        return
+    if isinstance(value, dict):
+        values = value.values()
+    elif isinstance(value, (list, tuple)):
+        values = value
+    else:
+        return
+    for item in values:
+        _rewind_multipart_files(item)
 
 # For LLM API functionality
 try:
@@ -361,7 +385,7 @@ class ComflyVideoAdapter:
     def save_to(self, output_path, format="auto", codec="auto", metadata=None):
         if self.is_url:
             try:
-                response = requests.get(self.video_url, stream=True)
+                response = requests.get(self.video_url, stream=True, timeout=300)
                 response.raise_for_status()
                 
                 with open(output_path, "wb") as f:
@@ -958,7 +982,9 @@ class Comfly_Mj(ComflyBaseNode):
             
             task_result = None
 
-            while True:
+            deadline = time.monotonic() + 1800
+            consecutive_failures = 0
+            while time.monotonic() < deadline:
                 time.sleep(1)
                 try:
                     task_result = self.midjourney_fetch_task_result_sync(taskId)
@@ -970,6 +996,7 @@ class Comfly_Mj(ComflyBaseNode):
                         raise Exception(error_message)  
                     if task_result.get("status") == "SUCCESS":
                         break
+                    consecutive_failures = 0
                         
                     progress = task_result.get("progress", 0)
                     try:
@@ -981,10 +1008,15 @@ class Comfly_Mj(ComflyBaseNode):
                 except Exception as e:
                     if "Midjourney task failed" in str(e):
                         raise  
+                    consecutive_failures += 1
+                    if consecutive_failures >= 6:
+                        raise RuntimeError("Midjourney polling failed 6 consecutive times") from e
                     print(f"Error fetching task result: {str(e)}")
                     time.sleep(2)
                     continue
-                
+            else:
+                raise TimeoutError("Midjourney polling timed out after 1800 seconds")
+
             image_url = task_result.get("imageUrl", "")
             prompt = task_result.get("prompt", text)
 
@@ -1288,7 +1320,8 @@ class Comfly_Mju(ComflyBaseNode):
                 raise self.MidjourneyError(f"Unexpected response from Midjourney API: {response}")
 
             new_task_id = response["result"]
-            while True:
+            deadline = asyncio.get_running_loop().time() + 1800
+            while asyncio.get_running_loop().time() < deadline:
                 await asyncio.sleep(1)
                 task_result = await self.midjourney_fetch_task_result(new_task_id)
 
@@ -1300,11 +1333,13 @@ class Comfly_Mju(ComflyBaseNode):
 
                 if task_result.get("status") == "SUCCESS":
                     break
+            else:
+                raise TimeoutError("Midjourney action polling timed out after 1800 seconds")
 
             if task_result.get("code") == 5 and task_result.get("description") == "task_no_found":
                 raise self.MidjourneyError(f"Task not found for taskId: {new_task_id}")
 
-            response = requests.get(task_result["imageUrl"])
+            response = requests.get(task_result["imageUrl"], timeout=self.timeout)
             image = Image.open(BytesIO(response.content))
             tensor_image = pil2tensor(image)
             return tensor_image, new_task_id 
@@ -1347,9 +1382,19 @@ class Comfly_Mju(ComflyBaseNode):
 
                 
                 task_result = None
-                while not task_result or task_result.get("status") != "SUCCESS":
+                deadline = asyncio.get_running_loop().time() + 1800
+                while (
+                    (not task_result or task_result.get("status") != "SUCCESS")
+                    and asyncio.get_running_loop().time() < deadline
+                ):
                     await asyncio.sleep(1)
                     task_result = await self.midjourney_fetch_task_result(taskId)
+                    if task_result.get("status") == "FAILURE":
+                        raise RuntimeError(
+                            f"Midjourney task failed: {task_result.get('fail_reason', 'unknown')}"
+                        )
+                if not task_result or task_result.get("status") != "SUCCESS":
+                    raise TimeoutError("Midjourney action polling timed out after 1800 seconds")
                 
                 image_url = task_result["imageUrl"]
                 return image_url
@@ -1820,7 +1865,7 @@ class Comfly_Mjv(ComflyBaseNode):
         }
         
         async with aiohttp.ClientSession() as session:
-            async with session.post(f"{self.midjourney_api_url[self.speed]}/mj/submit/action", headers=headers, json=payload) as response: 
+            async with session.post(f"{self.midjourney_api_url[self.speed]}/mj/submit/action", headers=headers, json=payload, timeout=self.timeout) as response:
                 if response.status == 200:
                     try:
                         data = await response.json()
@@ -1857,7 +1902,7 @@ class Comfly_Mjv(ComflyBaseNode):
             payload["maskBase64"] = maskBase64
 
         async with aiohttp.ClientSession() as session:
-            async with session.post(f"{self.midjourney_api_url[self.speed]}/mj/submit/modal", headers=headers, json=payload) as response:
+            async with session.post(f"{self.midjourney_api_url[self.speed]}/mj/submit/modal", headers=headers, json=payload, timeout=self.timeout) as response:
                 if response.status == 200:
                     data = await response.json()
                     return data
@@ -3203,16 +3248,6 @@ class Comfly_kling_multi_image2video:
     def __init__(self):
         self.api_key = get_config().get('api_key', '')
         self.timeout = 300
-        self.session = requests.Session()
-        retry_strategy = requests.packages.urllib3.util.retry.Retry(
-            total=5,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET", "POST"]
-        )
-        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
 
     def get_headers(self):
         return {
@@ -3235,49 +3270,18 @@ class Comfly_kling_multi_image2video:
             return None
     
     def make_request_with_retry(self, method, url, **kwargs):
-        max_retries = kwargs.pop('max_retries', 10)
+        kwargs.pop('max_retries', None)
         initial_timeout = kwargs.pop('initial_timeout', self.timeout)
-        
-        for attempt in range(1, max_retries + 1):
-            current_timeout = min(initial_timeout * (2 ** (attempt - 1)), 900)  
-            
-            try:
-                kwargs['timeout'] = current_timeout
-                
-                if method.lower() == 'get':
-                    response = self.session.get(url, **kwargs)
-                else:
-                    response = self.session.post(url, **kwargs)
-                
-                response.raise_for_status()
-                return response
-            
-            except requests.exceptions.Timeout as e:
-                if attempt == max_retries:
-                    raise
-                wait_time = min(2 ** (attempt - 1), 60)  
-                time.sleep(wait_time)
-            
-            except requests.exceptions.ConnectionError as e:
-                if attempt == max_retries:
-                    raise
-                wait_time = min(2 ** (attempt - 1), 60)
-                time.sleep(wait_time)
-            
-            except requests.exceptions.HTTPError as e:
-                if e.response.status_code in (400, 401, 403):
-                    print(f"Client error: {str(e)}")
-                    raise
-                if attempt == max_retries:
-                    raise
-                wait_time = min(2 ** (attempt - 1), 60)
-                time.sleep(wait_time)
-            
-            except Exception as e:
-                if attempt == max_retries:
-                    raise
-                wait_time = min(2 ** (attempt - 1), 60)
-                time.sleep(wait_time)
+        kwargs['timeout'] = min(initial_timeout, 900)
+        if method.lower() == 'get':
+            response = create_t8star_session().get(url, **kwargs)
+        else:
+            # Task creation is billable and has no idempotency key. Send once;
+            # retrying an ambiguous timeout can create a duplicate paid task.
+            with create_alternating_route_session(0) as session:
+                response = session.post(url, **kwargs)
+        response.raise_for_status()
+        return response
     
     def poll_task_status(self, task_id, max_attempts=100, initial_interval=2, max_interval=60, headers=None, pbar=None):
         attempt = 0
@@ -5909,16 +5913,8 @@ class Comfly_gpt_image_1_edit:
     def __init__(self):
         self.api_key = get_config().get('api_key', '')
         self.timeout = 900
-        self.session = requests.Session()
-        retry_strategy = requests.packages.urllib3.util.retry.Retry(
-            total=3,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET", "POST"]
-        )
-        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
+        self.last_edited_image = None
+        self.conversation_history = []
 
     def get_headers(self):
         return {
@@ -5937,56 +5933,21 @@ class Comfly_gpt_image_1_edit:
         return formatted_history.strip()
     
     def make_request_with_retry(self, url, data=None, files=None, max_retries=5, initial_timeout=300):
-        """Make a request with automatic retries and exponential backoff"""
-        for attempt in range(1, max_retries + 1):
-            current_timeout = min(initial_timeout * (1.5 ** (attempt - 1)), 1200)  
-            
-            try:
-                if files:
-                    response = self.session.post(
-                        url,
-                        headers=self.get_headers(),
-                        data=data,
-                        files=files,
-                        timeout=current_timeout
-                    )
-                else:
-                    response = self.session.post(
-                        url,
-                        headers=self.get_headers(),
-                        json=data,
-                        timeout=current_timeout
-                    )
-                
-                response.raise_for_status()
-                return response
-            
-            except requests.exceptions.Timeout as e:
-                if attempt == max_retries:
-                    raise TimeoutError(f"Request timed out after {max_retries} attempts. Last timeout: {current_timeout}s")
-                wait_time = min(2 ** (attempt - 1), 60)  
-                time.sleep(wait_time)
-            
-            except requests.exceptions.ConnectionError as e:
-                if attempt == max_retries:
-                    raise ConnectionError(f"Connection error after {max_retries} attempts: {str(e)}")
-                wait_time = min(2 ** (attempt - 1), 60)
-                time.sleep(wait_time)
-            
-            except requests.exceptions.HTTPError as e:
-                if e.response.status_code in (400, 401, 403):
-                    print(f"Client error: {str(e)}")
-                    raise
-                if attempt == max_retries:
-                    raise
-                wait_time = min(2 ** (attempt - 1), 60)
-                time.sleep(wait_time)
-            
-            except Exception as e:
-                if attempt == max_retries:
-                    raise
-                wait_time = min(2 ** (attempt - 1), 60)
-                time.sleep(wait_time)
+        """Send a billable image request once to avoid duplicate charges."""
+        with create_alternating_route_session(0) as route_session:
+            if files:
+                _rewind_multipart_files(files)
+                response = route_session.post(
+                    url, headers=self.get_headers(), data=data, files=files,
+                    timeout=min(initial_timeout, 1200)
+                )
+            else:
+                response = route_session.post(
+                    url, headers=self.get_headers(), json=data,
+                    timeout=min(initial_timeout, 1200)
+                )
+        response.raise_for_status()
+        return response
     
     def edit_image(self, prompt, model="gpt-image-1", n=1, quality="auto", 
               seed=0, api_key="", size="auto", clear_chats=True,
@@ -6208,9 +6169,11 @@ class Comfly_gpt_image_1_edit:
                 elif "url" in item:
                     image_urls.append(item["url"])
                     try:
-                        for download_attempt in range(1, max_retries + 1):
+                        for download_attempt in range(1, RESULT_DOWNLOAD_ATTEMPTS + 1):
                             try:
-                                img_response = requests.get(
+                                img_response = create_alternating_route_session(
+                                    download_attempt - 1
+                                ).get(
                                     item["url"], 
                                     timeout=min(initial_timeout * (1.5 ** (download_attempt - 1)), 900)
                                 )
@@ -6221,11 +6184,18 @@ class Comfly_gpt_image_1_edit:
                                 edited_images.append(edited_tensor)
                                 break
                             except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
-                                if download_attempt == max_retries:
-                                    print(f"Failed to download image after {max_retries} attempts: {str(e)}")
+                                if download_attempt == RESULT_DOWNLOAD_ATTEMPTS:
+                                    print(
+                                        "Failed to download image after "
+                                        f"{RESULT_DOWNLOAD_ATTEMPTS} attempts: {str(e)}"
+                                    )
                                     continue
                                 wait_time = min(2 ** (download_attempt - 1), 60)
-                                print(f"Image download error (attempt {download_attempt}/{max_retries}). Retrying in {wait_time} seconds...")
+                                print(
+                                    "Image download error "
+                                    f"(attempt {download_attempt}/{RESULT_DOWNLOAD_ATTEMPTS}). "
+                                    f"Retrying in {wait_time} seconds..."
+                                )
                                 time.sleep(wait_time)
                             except Exception as e:
                                 print(f"Error downloading image from URL: {str(e)}")
@@ -6564,16 +6534,6 @@ class Comfly_gpt_image_2_official:
     def __init__(self):
         self.api_key = get_config().get('api_key', '')
         self.timeout = 300
-        self.session = requests.Session()
-        retry_strategy = requests.packages.urllib3.util.retry.Retry(
-            total=3,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET", "POST"]
-        )
-        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
 
     def _auth_headers_bearer(self):
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -6585,44 +6545,20 @@ class Comfly_gpt_image_2_official:
         }
 
     def make_request_with_retry(self, url, data=None, files=None, max_retries=5, initial_timeout=300):
-        for attempt in range(1, max_retries + 1):
-            current_timeout = min(initial_timeout * (1.5 ** (attempt - 1)), 1200)
-            try:
-                if files is not None:
-                    response = self.session.post(
-                        url,
-                        headers=self._auth_headers_bearer(),
-                        data=data,
-                        files=files,
-                        timeout=current_timeout
-                    )
-                else:
-                    response = self.session.post(
-                        url,
-                        headers=self._headers_json(),
-                        json=data,
-                        timeout=current_timeout
-                    )
-                response.raise_for_status()
-                return response
-            except requests.exceptions.Timeout:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except requests.exceptions.ConnectionError:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except requests.exceptions.HTTPError as e:
-                if e.response is not None and e.response.status_code in (400, 401, 403):
-                    raise
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except Exception:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
+        with create_alternating_route_session(0) as route_session:
+            if files is not None:
+                _rewind_multipart_files(files)
+                response = route_session.post(
+                    url, headers=self._auth_headers_bearer(), data=data,
+                    files=files, timeout=min(initial_timeout, 1200)
+                )
+            else:
+                response = route_session.post(
+                    url, headers=self._headers_json(), json=data,
+                    timeout=min(initial_timeout, 1200)
+                )
+        response.raise_for_status()
+        return response
 
     def get_headers_multipart(self):
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -6718,7 +6654,7 @@ class Comfly_gpt_image_2_official:
 
         return data, request_files
 
-    def _decode_b64_url_one(self, b64_json, image_url, max_retries, initial_timeout):
+    def _decode_b64_url_one(self, b64_json, image_url, initial_timeout):
         """One image entry to tensor or None."""
         if b64_json:
             b64_data = b64_json
@@ -6730,9 +6666,11 @@ class Comfly_gpt_image_2_official:
             pil_img = Image.open(BytesIO(image_data))
             return pil2tensor(pil_img)
         if image_url:
-            for download_attempt in range(1, max_retries + 1):
+            for download_attempt in range(1, RESULT_DOWNLOAD_ATTEMPTS + 1):
                 try:
-                    img_response = requests.get(
+                    img_response = create_alternating_route_session(
+                        download_attempt - 1
+                    ).get(
                         image_url,
                         timeout=min(initial_timeout * (1.5 ** (download_attempt - 1)), 900),
                     )
@@ -6740,7 +6678,7 @@ class Comfly_gpt_image_2_official:
                     pil_img = Image.open(BytesIO(img_response.content))
                     return pil2tensor(pil_img)
                 except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                    if download_attempt == max_retries:
+                    if download_attempt == RESULT_DOWNLOAD_ATTEMPTS:
                         return None
                     time.sleep(min(2 ** (download_attempt - 1), 60))
         return None
@@ -6774,12 +6712,12 @@ class Comfly_gpt_image_2_official:
             url += f"&webhook={webhook.strip()}"
 
         pbar.update_absolute(10)
-        response = requests.post(
+        response = self.make_request_with_retry(
             url,
-            headers=self.get_headers_multipart(),
             data=data,
             files=request_files,
-            timeout=self.timeout,
+            max_retries=max_retries,
+            initial_timeout=initial_timeout,
         )
         if response.status_code != 200:
             raise RuntimeError(f"API Error: {response.status_code} - {response.text}")
@@ -6828,9 +6766,7 @@ class Comfly_gpt_image_2_official:
                         bj = item.get("b64_json", "") or ""
                         if u and not image_url_first:
                             image_url_first = u
-                        t = self._decode_b64_url_one(
-                            bj, u, max_retries, initial_timeout
-                        )
+                        t = self._decode_b64_url_one(bj, u, initial_timeout)
                         if t is not None:
                             tensors.append(t)
                     if not tensors:
@@ -6848,7 +6784,7 @@ class Comfly_gpt_image_2_official:
                 print(f"Error polling task status: {str(e)}")
         raise RuntimeError(f"Failed to get image after {max_poll_attempts} poll attempts")
 
-    def _items_to_tensors(self, result, max_retries=5, initial_timeout=300):
+    def _items_to_tensors(self, result, initial_timeout=300):
         """Parse Images API data[] b64_json or url into a list of tensors."""
         out = []
         for item in result.get("data", []) or []:
@@ -6862,9 +6798,11 @@ class Comfly_gpt_image_2_official:
                 pil_img = Image.open(BytesIO(image_data))
                 out.append(pil2tensor(pil_img))
             elif "url" in item and item["url"]:
-                for download_attempt in range(1, max_retries + 1):
+                for download_attempt in range(1, RESULT_DOWNLOAD_ATTEMPTS + 1):
                     try:
-                        img_response = requests.get(
+                        img_response = create_alternating_route_session(
+                            download_attempt - 1
+                        ).get(
                             item["url"],
                             timeout=min(initial_timeout * (1.5 ** (download_attempt - 1)), 900)
                         )
@@ -6873,7 +6811,7 @@ class Comfly_gpt_image_2_official:
                         out.append(pil2tensor(pil_img))
                         break
                     except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                        if download_attempt == max_retries:
+                        if download_attempt == RESULT_DOWNLOAD_ATTEMPTS:
                             break
                         time.sleep(min(2 ** (download_attempt - 1), 60))
         return out
@@ -7014,7 +6952,7 @@ class Comfly_gpt_image_2_official:
                     raise RuntimeError(f"[Comfly_gpt_image_2_official] {msg}")
                 return (blank_t, "", msg)
 
-            tensors = self._items_to_tensors(result, max_retries, initial_timeout)
+            tensors = self._items_to_tensors(result, initial_timeout)
             pbar.update_absolute(95)
 
             if not tensors:
@@ -7230,16 +7168,6 @@ class Comfly_gpt_image_2_official_ratio:
     def __init__(self):
         self.api_key = get_config().get('api_key', '')
         self.timeout = 300
-        self.session = requests.Session()
-        retry_strategy = requests.packages.urllib3.util.retry.Retry(
-            total=3,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET", "POST"]
-        )
-        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
 
     def _auth_headers_bearer(self):
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -7251,44 +7179,20 @@ class Comfly_gpt_image_2_official_ratio:
         }
 
     def make_request_with_retry(self, url, data=None, files=None, max_retries=5, initial_timeout=300):
-        for attempt in range(1, max_retries + 1):
-            current_timeout = min(initial_timeout * (1.5 ** (attempt - 1)), 1200)
-            try:
-                if files is not None:
-                    response = self.session.post(
-                        url,
-                        headers=self._auth_headers_bearer(),
-                        data=data,
-                        files=files,
-                        timeout=current_timeout
-                    )
-                else:
-                    response = self.session.post(
-                        url,
-                        headers=self._headers_json(),
-                        json=data,
-                        timeout=current_timeout
-                    )
-                response.raise_for_status()
-                return response
-            except requests.exceptions.Timeout:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except requests.exceptions.ConnectionError:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except requests.exceptions.HTTPError as e:
-                if e.response is not None and e.response.status_code in (400, 401, 403):
-                    raise
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except Exception:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
+        with create_alternating_route_session(0) as route_session:
+            if files is not None:
+                _rewind_multipart_files(files)
+                response = route_session.post(
+                    url, headers=self._auth_headers_bearer(), data=data,
+                    files=files, timeout=min(initial_timeout, 1200)
+                )
+            else:
+                response = route_session.post(
+                    url, headers=self._headers_json(), json=data,
+                    timeout=min(initial_timeout, 1200)
+                )
+        response.raise_for_status()
+        return response
 
     def get_headers_multipart(self):
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -7392,7 +7296,7 @@ class Comfly_gpt_image_2_official_ratio:
 
         return data, request_files
 
-    def _decode_b64_url_one(self, b64_json, image_url, max_retries, initial_timeout):
+    def _decode_b64_url_one(self, b64_json, image_url, initial_timeout):
         """One image entry to tensor or None."""
         if b64_json:
             b64_data = b64_json
@@ -7404,9 +7308,11 @@ class Comfly_gpt_image_2_official_ratio:
             pil_img = Image.open(BytesIO(image_data))
             return pil2tensor(pil_img)
         if image_url:
-            for download_attempt in range(1, max_retries + 1):
+            for download_attempt in range(1, RESULT_DOWNLOAD_ATTEMPTS + 1):
                 try:
-                    img_response = requests.get(
+                    img_response = create_alternating_route_session(
+                        download_attempt - 1
+                    ).get(
                         image_url,
                         timeout=min(initial_timeout * (1.5 ** (download_attempt - 1)), 900),
                     )
@@ -7414,7 +7320,7 @@ class Comfly_gpt_image_2_official_ratio:
                     pil_img = Image.open(BytesIO(img_response.content))
                     return pil2tensor(pil_img)
                 except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                    if download_attempt == max_retries:
+                    if download_attempt == RESULT_DOWNLOAD_ATTEMPTS:
                         return None
                     time.sleep(min(2 ** (download_attempt - 1), 60))
         return None
@@ -7467,12 +7373,12 @@ class Comfly_gpt_image_2_official_ratio:
             url += f"&webhook={webhook.strip()}"
 
         pbar.update_absolute(10)
-        response = requests.post(
+        response = self.make_request_with_retry(
             url,
-            headers=self.get_headers_multipart(),
             data=data,
             files=request_files,
-            timeout=self.timeout,
+            max_retries=max_retries,
+            initial_timeout=initial_timeout,
         )
         if response.status_code != 200:
             raise RuntimeError(f"API Error: {response.status_code} - {response.text}")
@@ -7521,9 +7427,7 @@ class Comfly_gpt_image_2_official_ratio:
                         bj = item.get("b64_json", "") or ""
                         if u and not image_url_first:
                             image_url_first = u
-                        t = self._decode_b64_url_one(
-                            bj, u, max_retries, initial_timeout
-                        )
+                        t = self._decode_b64_url_one(bj, u, initial_timeout)
                         if t is not None:
                             tensors.append(t)
                     if not tensors:
@@ -7541,7 +7445,7 @@ class Comfly_gpt_image_2_official_ratio:
                 print(f"Error polling task status: {str(e)}")
         raise RuntimeError(f"Failed to get image after {max_poll_attempts} poll attempts")
 
-    def _items_to_tensors(self, result, max_retries=5, initial_timeout=300):
+    def _items_to_tensors(self, result, initial_timeout=300):
         """Parse Images API data[] b64_json or url into a list of tensors."""
         out = []
         for item in result.get("data", []) or []:
@@ -7555,9 +7459,11 @@ class Comfly_gpt_image_2_official_ratio:
                 pil_img = Image.open(BytesIO(image_data))
                 out.append(pil2tensor(pil_img))
             elif "url" in item and item["url"]:
-                for download_attempt in range(1, max_retries + 1):
+                for download_attempt in range(1, RESULT_DOWNLOAD_ATTEMPTS + 1):
                     try:
-                        img_response = requests.get(
+                        img_response = create_alternating_route_session(
+                            download_attempt - 1
+                        ).get(
                             item["url"],
                             timeout=min(initial_timeout * (1.5 ** (download_attempt - 1)), 900)
                         )
@@ -7566,7 +7472,7 @@ class Comfly_gpt_image_2_official_ratio:
                         out.append(pil2tensor(pil_img))
                         break
                     except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                        if download_attempt == max_retries:
+                        if download_attempt == RESULT_DOWNLOAD_ATTEMPTS:
                             break
                         time.sleep(min(2 ** (download_attempt - 1), 60))
         return out
@@ -7727,7 +7633,7 @@ class Comfly_gpt_image_2_official_ratio:
                 print(msg)
                 return (blank_t, "", msg)
 
-            tensors = self._items_to_tensors(result, max_retries, initial_timeout)
+            tensors = self._items_to_tensors(result, initial_timeout)
             pbar.update_absolute(95)
 
             if not tensors:
@@ -25019,16 +24925,6 @@ class Comfly_gpt_image_2_official_ratio_stable:
     def __init__(self):
         self.api_key = get_config().get('api_key', '')
         self.timeout = 300
-        self.session = requests.Session()
-        retry_strategy = requests.packages.urllib3.util.retry.Retry(
-            total=3,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET", "POST"]
-        )
-        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
 
     def _auth_headers_bearer(self):
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -25040,44 +24936,20 @@ class Comfly_gpt_image_2_official_ratio_stable:
         }
 
     def make_request_with_retry(self, url, data=None, files=None, max_retries=5, initial_timeout=300):
-        for attempt in range(1, max_retries + 1):
-            current_timeout = min(initial_timeout * (1.5 ** (attempt - 1)), 1200)
-            try:
-                if files is not None:
-                    response = self.session.post(
-                        url,
-                        headers=self._auth_headers_bearer(),
-                        data=data,
-                        files=files,
-                        timeout=current_timeout
-                    )
-                else:
-                    response = self.session.post(
-                        url,
-                        headers=self._headers_json(),
-                        json=data,
-                        timeout=current_timeout
-                    )
-                response.raise_for_status()
-                return response
-            except requests.exceptions.Timeout:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except requests.exceptions.ConnectionError:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except requests.exceptions.HTTPError as e:
-                if e.response is not None and e.response.status_code in (400, 401, 403):
-                    raise
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
-            except Exception:
-                if attempt == max_retries:
-                    raise
-                time.sleep(min(2 ** (attempt - 1), 60))
+        with create_alternating_route_session(0) as route_session:
+            if files is not None:
+                _rewind_multipart_files(files)
+                response = route_session.post(
+                    url, headers=self._auth_headers_bearer(), data=data,
+                    files=files, timeout=min(initial_timeout, 1200)
+                )
+            else:
+                response = route_session.post(
+                    url, headers=self._headers_json(), json=data,
+                    timeout=min(initial_timeout, 1200)
+                )
+        response.raise_for_status()
+        return response
 
     def get_headers_multipart(self):
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -25185,7 +25057,7 @@ class Comfly_gpt_image_2_official_ratio_stable:
 
         return data, request_files
 
-    def _decode_b64_url_one(self, b64_json, image_url, max_retries, initial_timeout):
+    def _decode_b64_url_one(self, b64_json, image_url, initial_timeout):
         """One image entry to tensor or None."""
         if b64_json:
             b64_data = b64_json
@@ -25197,9 +25069,11 @@ class Comfly_gpt_image_2_official_ratio_stable:
             pil_img = Image.open(BytesIO(image_data))
             return pil2tensor(pil_img)
         if image_url:
-            for download_attempt in range(1, max_retries + 1):
+            for download_attempt in range(1, RESULT_DOWNLOAD_ATTEMPTS + 1):
                 try:
-                    img_response = requests.get(
+                    img_response = create_alternating_route_session(
+                        download_attempt - 1
+                    ).get(
                         image_url,
                         timeout=min(initial_timeout * (1.5 ** (download_attempt - 1)), 900),
                     )
@@ -25207,7 +25081,7 @@ class Comfly_gpt_image_2_official_ratio_stable:
                     pil_img = Image.open(BytesIO(img_response.content))
                     return pil2tensor(pil_img)
                 except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                    if download_attempt == max_retries:
+                    if download_attempt == RESULT_DOWNLOAD_ATTEMPTS:
                         return None
                     time.sleep(min(2 ** (download_attempt - 1), 60))
         return None
@@ -25237,12 +25111,12 @@ class Comfly_gpt_image_2_official_ratio_stable:
             url += f"&webhook={webhook.strip()}"
 
         pbar.update_absolute(10)
-        response = requests.post(
+        response = self.make_request_with_retry(
             url,
-            headers=self.get_headers_multipart(),
             data=data,
             files=request_files,
-            timeout=self.timeout,
+            max_retries=max_retries,
+            initial_timeout=initial_timeout,
         )
         if response.status_code != 200:
             raise RuntimeError(f"API Error: {response.status_code} - {response.text}")
@@ -25291,9 +25165,7 @@ class Comfly_gpt_image_2_official_ratio_stable:
                         bj = item.get("b64_json", "") or ""
                         if u and not image_url_first:
                             image_url_first = u
-                        t = self._decode_b64_url_one(
-                            bj, u, max_retries, initial_timeout
-                        )
+                        t = self._decode_b64_url_one(bj, u, initial_timeout)
                         if t is not None:
                             tensors.append(t)
                     if not tensors:
@@ -25311,7 +25183,7 @@ class Comfly_gpt_image_2_official_ratio_stable:
                 print(f"Error polling task status: {str(e)}")
         raise RuntimeError(f"Failed to get image after {max_poll_attempts} poll attempts")
 
-    def _items_to_tensors(self, result, max_retries=5, initial_timeout=300):
+    def _items_to_tensors(self, result, initial_timeout=300):
         """Parse Images API data[] b64_json or url into a list of tensors."""
         out = []
         for item in result.get("data", []) or []:
@@ -25325,9 +25197,11 @@ class Comfly_gpt_image_2_official_ratio_stable:
                 pil_img = Image.open(BytesIO(image_data))
                 out.append(pil2tensor(pil_img))
             elif "url" in item and item["url"]:
-                for download_attempt in range(1, max_retries + 1):
+                for download_attempt in range(1, RESULT_DOWNLOAD_ATTEMPTS + 1):
                     try:
-                        img_response = requests.get(
+                        img_response = create_alternating_route_session(
+                            download_attempt - 1
+                        ).get(
                             item["url"],
                             timeout=min(initial_timeout * (1.5 ** (download_attempt - 1)), 900)
                         )
@@ -25336,7 +25210,7 @@ class Comfly_gpt_image_2_official_ratio_stable:
                         out.append(pil2tensor(pil_img))
                         break
                     except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                        if download_attempt == max_retries:
+                        if download_attempt == RESULT_DOWNLOAD_ATTEMPTS:
                             break
                         time.sleep(min(2 ** (download_attempt - 1), 60))
         return out
@@ -25463,7 +25337,7 @@ class Comfly_gpt_image_2_official_ratio_stable:
                 print(msg)
                 return (blank_t, "", msg)
 
-            tensors = self._items_to_tensors(result, max_retries, initial_timeout)
+            tensors = self._items_to_tensors(result, initial_timeout)
             pbar.update_absolute(95)
 
             if not tensors:

--- a/media_download.py
+++ b/media_download.py
@@ -5,9 +5,27 @@ from __future__ import annotations
 import io
 import time
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 from PIL import Image, UnidentifiedImageError
+
+try:
+    from .t8star_http import (
+        T8STAR_RETRY_DELAYS,
+        T8STAR_RETRYABLE_NETWORK_ERRORS,
+        T8STAR_RETRYABLE_STATUS_CODES,
+        T8STAR_ROUTE_ATTEMPTS,
+        create_alternating_route_session,
+    )
+except ImportError:
+    from t8star_http import (
+        T8STAR_RETRY_DELAYS,
+        T8STAR_RETRYABLE_NETWORK_ERRORS,
+        T8STAR_RETRYABLE_STATUS_CODES,
+        T8STAR_ROUTE_ATTEMPTS,
+        create_alternating_route_session,
+    )
 
 
 _IMAGE_HEADERS = {
@@ -30,92 +48,112 @@ def _failure_summary(error: BaseException) -> str:
     return type(error).__name__
 
 
+def _safe_url(url: str) -> str:
+    parsed = urlsplit(url)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+
+def _download_image(
+    url: str,
+    *,
+    mode: str,
+    timeout: float,
+    max_attempts: int,
+    request_get: Any,
+) -> Image.Image:
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("Image result URL is empty")
+    attempts = max(1, min(int(max_attempts), len(T8STAR_ROUTE_ATTEMPTS)))
+    last_error: BaseException | None = None
+    safe_url = _safe_url(url)
+
+    for attempt in range(attempts):
+        if attempt:
+            time.sleep(T8STAR_RETRY_DELAYS[attempt - 1])
+        response = None
+        try:
+            if request_get is None:
+                with create_alternating_route_session(attempt) as session:
+                    response = session.get(
+                        url, headers=_IMAGE_HEADERS, timeout=_request_timeout(timeout)
+                    )
+                    image = _decode_image_response(response, mode)
+            else:
+                response = request_get(
+                    url, headers=_IMAGE_HEADERS, timeout=_request_timeout(timeout)
+                )
+                image = _decode_image_response(response, mode)
+            return image
+        except requests.exceptions.HTTPError as error:
+            last_error = error
+            status = error.response.status_code if error.response is not None else None
+            if status not in T8STAR_RETRYABLE_STATUS_CODES:
+                raise
+        except (*T8STAR_RETRYABLE_NETWORK_ERRORS, UnidentifiedImageError, OSError, ValueError) as error:
+            last_error = error
+        finally:
+            close = getattr(response, "close", None)
+            if callable(close):
+                close()
+        print(
+            f"[zhenzhen] Image download failed for {safe_url} "
+            f"(attempt {attempt + 1}/{attempts}, "
+            f"mode={T8STAR_ROUTE_ATTEMPTS[attempt][0]}): "
+            f"{type(last_error).__name__}"
+        )
+
+    summary = _failure_summary(last_error or RuntimeError("unknown image error"))
+    raise RuntimeError(
+        f"Image result download failed after {attempts} attempts ({summary})"
+    ) from last_error
+
+
+def _decode_image_response(response: requests.Response, mode: str) -> Image.Image:
+    if response.status_code in T8STAR_RETRYABLE_STATUS_CODES:
+        raise requests.exceptions.HTTPError(
+            f"retryable HTTP {response.status_code}", response=response
+        )
+    response.raise_for_status()
+    content = response.content
+    if not content:
+        raise OSError("Image response was empty")
+    with Image.open(io.BytesIO(content)) as image:
+        image.load()
+        return image.convert(mode)
+
+
 def download_image_with_retry(
     url: str,
     *,
     timeout: float = 300,
-    max_attempts: int = 5,
+    max_attempts: int = len(T8STAR_ROUTE_ATTEMPTS),
     request_get: Any = None,
 ) -> Image.Image:
     """Download and fully decode an image, retrying transient or not-yet-ready results."""
-    if not isinstance(url, str) or not url.strip():
-        raise ValueError("Image result URL is empty")
-    if max_attempts < 1:
-        raise ValueError("max_attempts must be at least 1")
-
-    getter = request_get or requests.get
-    last_error: BaseException | None = None
-    for attempt in range(1, max_attempts + 1):
-        try:
-            response = getter(
-                url,
-                headers=_IMAGE_HEADERS,
-                timeout=_request_timeout(timeout),
-            )
-            response.raise_for_status()
-            if not response.content:
-                raise OSError("Image response was empty")
-            with Image.open(io.BytesIO(response.content)) as image:
-                image.load()
-                return image.convert("RGB")
-        except (
-            requests.exceptions.RequestException,
-            UnidentifiedImageError,
-            OSError,
-            ValueError,
-        ) as error:
-            last_error = error
-            if attempt < max_attempts:
-                time.sleep(min(2 ** (attempt - 1), 8))
-
-    summary = _failure_summary(last_error or RuntimeError("unknown image error"))
-    raise RuntimeError(
-        f"Image result download failed after {max_attempts} attempts ({summary})"
-    ) from last_error
+    return _download_image(
+        url,
+        mode="RGB",
+        timeout=timeout,
+        max_attempts=max_attempts,
+        request_get=request_get,
+    )
 
 
 def download_image_with_alpha_retry(
     url: str,
     *,
     timeout: float = 300,
-    max_attempts: int = 5,
+    max_attempts: int = len(T8STAR_ROUTE_ATTEMPTS),
     request_get: Any = None,
 ) -> Image.Image:
     """Download and fully decode an image without discarding its alpha channel."""
-    if not isinstance(url, str) or not url.strip():
-        raise ValueError("Image result URL is empty")
-    if max_attempts < 1:
-        raise ValueError("max_attempts must be at least 1")
-
-    getter = request_get or requests.get
-    last_error: BaseException | None = None
-    for attempt in range(1, max_attempts + 1):
-        try:
-            response = getter(
-                url,
-                headers=_IMAGE_HEADERS,
-                timeout=_request_timeout(timeout),
-            )
-            response.raise_for_status()
-            if not response.content:
-                raise OSError("Image response was empty")
-            with Image.open(io.BytesIO(response.content)) as image:
-                image.load()
-                return image.convert("RGBA")
-        except (
-            requests.exceptions.RequestException,
-            UnidentifiedImageError,
-            OSError,
-            ValueError,
-        ) as error:
-            last_error = error
-            if attempt < max_attempts:
-                time.sleep(min(2 ** (attempt - 1), 8))
-
-    summary = _failure_summary(last_error or RuntimeError("unknown image error"))
-    raise RuntimeError(
-        f"Image result download failed after {max_attempts} attempts ({summary})"
-    ) from last_error
+    return _download_image(
+        url,
+        mode="RGBA",
+        timeout=timeout,
+        max_attempts=max_attempts,
+        request_get=request_get,
+    )
 
 
 __all__ = ["download_image_with_retry", "download_image_with_alpha_retry"]

--- a/midjourney_low_price_nodes.py
+++ b/midjourney_low_price_nodes.py
@@ -6,7 +6,6 @@ import io
 import json
 import mimetypes
 import os
-import ssl
 import tempfile
 import threading
 import time
@@ -23,15 +22,19 @@ from PIL import Image, ImageDraw, ImageFont
 try:
     from .seedance_low_price_nodes import (
         COMFYUI_AVAILABLE,
-        BUNDLED_ROOT_YR_CERT,
         CONFIG_TYPE,
-        DEFAULT_BASE_URL,
+        IMAGE_DOWNLOAD_MAX_BYTES,
+        NETWORK_ROUTE_ATTEMPTS,
+        VIDEO_DOWNLOAD_MAX_BYTES,
         VIDEO_TYPE,
         SeedanceLowPriceError,
-        _SSLContextAdapter,
+        _build_session,
         _headers,
+        _post_once,
+        _request_with_retry,
         _response_json,
         _video_from_path,
+        _write_limited,
         extract_error_message,
         image_to_png_bytes,
         make_error_video,
@@ -41,15 +44,19 @@ try:
 except ImportError:
     from seedance_low_price_nodes import (
         COMFYUI_AVAILABLE,
-        BUNDLED_ROOT_YR_CERT,
         CONFIG_TYPE,
-        DEFAULT_BASE_URL,
+        IMAGE_DOWNLOAD_MAX_BYTES,
+        NETWORK_ROUTE_ATTEMPTS,
+        VIDEO_DOWNLOAD_MAX_BYTES,
         VIDEO_TYPE,
         SeedanceLowPriceError,
-        _SSLContextAdapter,
+        _build_session,
         _headers,
+        _post_once,
+        _request_with_retry,
         _response_json,
         _video_from_path,
+        _write_limited,
         extract_error_message,
         image_to_png_bytes,
         make_error_video,
@@ -66,27 +73,19 @@ except ImportError:
 _SESSION_LOCAL = threading.local()
 
 
-def _midjourney_session() -> requests.Session:
+def _midjourney_session(
+    route_attempt: Optional[int] = None,
+) -> requests.Session:
+    if route_attempt is not None:
+        _mode, trust_env = NETWORK_ROUTE_ATTEMPTS[
+            route_attempt % len(NETWORK_ROUTE_ATTEMPTS)
+        ]
+        return _build_session(trust_env=trust_env)
+
     session = getattr(_SESSION_LOCAL, "session", None)
     if session is not None:
         return session
-    if not BUNDLED_ROOT_YR_CERT.is_file():
-        raise RuntimeError(
-            f"Bundled TLS certificate is missing: "
-            f"{BUNDLED_ROOT_YR_CERT.name}"
-        )
-    context = ssl.create_default_context(cafile=requests.certs.where())
-    context.load_verify_locations(cafile=str(BUNDLED_ROOT_YR_CERT))
-    session = requests.Session()
-    session.mount(
-        f"{DEFAULT_BASE_URL}/",
-        _SSLContextAdapter(
-            context,
-            pool_connections=8,
-            pool_maxsize=30,
-            pool_block=True,
-        ),
-    )
+    session = _build_session()
     _SESSION_LOCAL.session = session
     return session
 
@@ -459,45 +458,22 @@ def submit_midjourney_action(
     if not action_text:
         raise SeedanceLowPriceError("Midjourney action is required")
     url = f"{config['base_url']}/v1/midjourney/generations/{action_text}"
-    last_error = "unknown error"
-    for attempt in range(3):
-        if attempt:
-            sleep(min(2 ** attempt + 1, 15))
-        try:
-            response = _midjourney_session().post(
-                url,
-                headers=_headers(config["api_key"]),
-                json=payload,
-                timeout=config.get("timeout", 60),
-            )
-        except requests.ConnectTimeout as exc:
-            last_error = f"network error: {type(exc).__name__}: {exc}"
-            continue
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                "Midjourney submit transport failed after the request may have "
-                "reached the server; it was not retried to avoid a duplicate "
-                f"paid task: {type(exc).__name__}: {exc}"
-            ) from exc
-
-        data = _response_json(response)
-        message = extract_error_message(data, response.text[:300])
-        if response.status_code == 429 or response.status_code >= 500:
-            last_error = f"HTTP {response.status_code}: {message}"
-            continue
-        if not 200 <= response.status_code < 300:
-            raise SeedanceLowPriceError(
-                f"Midjourney {action_text} rejected "
-                f"(HTTP {response.status_code}): {message}"
-            )
-        if not isinstance(data, dict):
-            raise SeedanceLowPriceError(
-                "Midjourney submit returned a non-object JSON response"
-            )
-        return _extract_task_id(data), data
-    raise RuntimeError(
-        f"Midjourney submit failed after 3 attempts: {last_error}"
+    response = _post_once(
+        url, headers=_headers(config["api_key"]), json=payload,
+        timeout=config.get("timeout", 60),
     )
+    data = _response_json(response)
+    message = extract_error_message(data, response.text[:300])
+    if not 200 <= response.status_code < 300:
+        raise SeedanceLowPriceError(
+            f"Midjourney {action_text} rejected "
+            f"(HTTP {response.status_code}): {message}"
+        )
+    if not isinstance(data, dict):
+        raise SeedanceLowPriceError(
+            "Midjourney submit returned a non-object JSON response"
+        )
+    return _extract_task_id(data), data
 
 
 def poll_midjourney_task(
@@ -532,19 +508,16 @@ def poll_midjourney_task(
                 continue
             route = route_template.format(task_id=task_id_text)
             try:
-                candidate = _midjourney_session().get(
-                    f"{config['base_url']}{route}",
+                candidate = _request_with_retry(
+                    "get", f"{config['base_url']}{route}", sleep=sleep,
+                    session_factory=_midjourney_session,
                     headers=_headers(config["api_key"], json_content=False),
                     timeout=30,
                 )
-            except requests.RequestException:
-                failures += 1
-                if failures >= 6:
-                    raise RuntimeError(
-                        "Midjourney polling failed after repeated network errors"
-                    )
-                response = None
-                break
+            except requests.RequestException as exc:
+                raise RuntimeError(
+                    "Midjourney polling failed after 4 route attempts"
+                ) from exc
             if candidate.status_code == 404 and active_route is None:
                 last_not_found = candidate
                 continue
@@ -562,15 +535,6 @@ def poll_midjourney_task(
 
         data = _response_json(response)
         message = extract_error_message(data, response.text[:300])
-        if response.status_code == 429 or response.status_code >= 500:
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(
-                    f"Midjourney polling repeatedly returned "
-                    f"HTTP {response.status_code}: {message}"
-                )
-            sleep(min(failures * 2, 10))
-            continue
         if response.status_code != 200:
             raise SeedanceLowPriceError(
                 f"Midjourney polling rejected "
@@ -765,47 +729,39 @@ def _download_file(
     url: str,
     prefix: str,
     fallback_extension: str,
-    max_retries: int = 3,
+    max_retries: int = len(NETWORK_ROUTE_ATTEMPTS),
 ) -> str:
     output_dir = _output_directory()
-    last_error: Optional[Exception] = None
-    for attempt in range(max_retries):
-        if attempt:
-            time.sleep(2 ** attempt)
-        path = ""
-        try:
-            response = _midjourney_session().get(
-                url, stream=True, timeout=300
+    max_bytes = (
+        VIDEO_DOWNLOAD_MAX_BYTES
+        if fallback_extension.lstrip(".") == "mp4"
+        else IMAGE_DOWNLOAD_MAX_BYTES
+    )
+
+    def consume(response: requests.Response) -> str:
+        response.raise_for_status()
+        extension = os.path.splitext(urlsplit(url).path)[1].lower()
+        if not extension or len(extension) > 10:
+            content_type = response.headers.get("Content-Type", "")
+            media_type = content_type.split(";", 1)[0].strip().lower()
+            extension = mimetypes.guess_extension(media_type) or (
+                f".{fallback_extension.lstrip('.')}"
             )
-            response.raise_for_status()
-            extension = os.path.splitext(urlsplit(url).path)[1].lower()
-            if not extension or len(extension) > 10:
-                content_type = response.headers.get("Content-Type", "")
-                media_type = content_type.split(";", 1)[0].strip().lower()
-                extension = mimetypes.guess_extension(media_type) or (
-                    f".{fallback_extension.lstrip('.')}"
-                )
-            path = os.path.join(
-                output_dir,
-                f"{prefix}_{uuid.uuid4().hex[:12]}{extension}",
-            )
-            with open(path, "wb") as handle:
-                for chunk in response.iter_content(chunk_size=65536):
-                    if chunk:
-                        handle.write(chunk)
-            if os.path.getsize(path) <= 0:
-                raise RuntimeError("downloaded file is empty")
-            return path
-        except Exception as exc:
-            last_error = exc
-            if path:
-                try:
-                    os.remove(path)
-                except OSError:
-                    pass
-    raise RuntimeError(
-        f"Midjourney result download failed after "
-        f"{max_retries} attempts: {last_error}"
+        path = os.path.join(
+            output_dir, f"{prefix}_{uuid.uuid4().hex[:12]}{extension}"
+        )
+        _write_limited(
+            response, path, max_bytes, "Midjourney result download"
+        )
+        return path
+
+    return _request_with_retry(
+        "get",
+        url,
+        session_factory=_midjourney_session,
+        _consume=consume,
+        stream=True,
+        timeout=300,
     )
 
 

--- a/seedance_low_price_nodes.py
+++ b/seedance_low_price_nodes.py
@@ -42,6 +42,7 @@ except ImportError:
 
 
 DEFAULT_BASE_URL = "https://api.seedance.nz"
+ALLOWED_API_HOSTS = frozenset({"api.seedance.nz"})
 CONFIG_TYPE = "ZHENZHEN_SEEDANCE2_CONFIG"
 BUNDLED_ROOT_YR_CERT = (
     Path(__file__).resolve().parent / "certs" / "root-yr-by-x1.pem"
@@ -50,6 +51,9 @@ PROMPT_MAX_LENGTH = 20480
 IMAGE_MAX_BYTES = 30 * 1024 * 1024
 MEDIA_MAX_BYTES = 50 * 1024 * 1024
 DOMESTIC_FAST_AUDIO_MAX_BYTES = 15 * 1024 * 1024
+IMAGE_DOWNLOAD_MAX_BYTES = 64 * 1024 * 1024
+AUDIO_DOWNLOAD_MAX_BYTES = 512 * 1024 * 1024
+VIDEO_DOWNLOAD_MAX_BYTES = 2 * 1024 * 1024 * 1024
 SECONDS = ["-1"] + [str(value) for value in range(4, 16)]
 RESOLUTIONS = ["480p", "720p", "1080p", "2k", "4k", "native1080p", "native4k"]
 RATIOS = ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16", "21:9"]
@@ -99,16 +103,35 @@ class SeedanceLowPriceError(RuntimeError):
 
 def normalize_base_url(value: str) -> str:
     raw = str(value or DEFAULT_BASE_URL).strip()
-    parsed = urlsplit(raw)
-    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+    try:
+        parsed = urlsplit(raw)
+        port = parsed.port
+    except ValueError as exc:
+        raise SeedanceLowPriceError(f"Invalid Seedance base_url: {exc}") from exc
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    reserved_test_host = hostname.endswith((".test", ".example"))
+    if (
+        parsed.scheme.lower() != "https"
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or (hostname not in ALLOWED_API_HOSTS and not reserved_test_host)
+        or parsed.query
+        or parsed.fragment
+    ):
         raise SeedanceLowPriceError(
-            f"Invalid Seedance base_url '{raw}'. Expected an http(s) site root."
+            "Seedance base_url must be the trusted HTTPS API root "
+            f"{DEFAULT_BASE_URL}."
         )
 
     path = parsed.path.rstrip("/")
-    if parsed.netloc.lower() == "api.seedance.nz" and path.lower().startswith("/docs"):
+    if hostname == "api.seedance.nz" and path.lower().startswith("/docs"):
         path = ""
-    return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+    if path:
+        raise SeedanceLowPriceError("Seedance base_url must not contain an API path.")
+    netloc = hostname if port is None else f"{hostname}:{port}"
+    return urlunsplit(("https", netloc, "", "", "")).rstrip("/")
 
 
 def _unwrap_api_config(api_config: Any) -> Optional[Dict[str, Any]]:
@@ -119,7 +142,7 @@ def _unwrap_api_config(api_config: Any) -> Optional[Dict[str, Any]]:
 
 
 def resolve_config(api_config: Any = None) -> Dict[str, Any]:
-    """Resolve an explicit workflow setting, then optional environment values."""
+    """Resolve credentials from the connected workflow settings only."""
     settings = _unwrap_api_config(api_config)
     source = ""
     base_url = ""
@@ -133,12 +156,6 @@ def resolve_config(api_config: Any = None) -> Dict[str, Any]:
                 "Connected Seedance 2.0 Low Price Settings has an empty api_key."
             )
         source = "settings_node"
-
-    if not api_key:
-        api_key = str(os.environ.get("SEEDANCE_API_KEY") or "").strip()
-        base_url = str(os.environ.get("SEEDANCE_BASE_URL") or "").strip()
-        if api_key:
-            source = "environment"
 
     if not api_key:
         raise SeedanceLowPriceError(
@@ -196,12 +213,16 @@ class _SSLContextAdapter(requests.adapters.HTTPAdapter):
 
 _SESSION_LOCAL = threading.local()
 
+NETWORK_ROUTE_ATTEMPTS = (
+    ("direct", False),
+    ("proxy", True),
+    ("direct", False),
+    ("proxy", True),
+)
+NETWORK_RETRY_DELAYS = (1, 5, 10)
+NETWORK_RETRYABLE_STATUS_CODES = frozenset({429, 502, 503, 504})
 
-def _get_session() -> requests.Session:
-    session = getattr(_SESSION_LOCAL, "session", None)
-    if session is not None:
-        return session
-
+def _build_session(trust_env: bool = True) -> requests.Session:
     if not BUNDLED_ROOT_YR_CERT.is_file():
         raise RuntimeError(
             f"Bundled TLS certificate is missing: {BUNDLED_ROOT_YR_CERT.name}"
@@ -211,6 +232,7 @@ def _get_session() -> requests.Session:
     context.load_verify_locations(cafile=str(BUNDLED_ROOT_YR_CERT))
 
     session = requests.Session()
+    session.trust_env = trust_env
     session.mount(
         f"{DEFAULT_BASE_URL}/",
         _SSLContextAdapter(
@@ -220,8 +242,127 @@ def _get_session() -> requests.Session:
             pool_block=True,
         ),
     )
+    return session
+
+
+def _get_session(route_attempt: Optional[int] = None) -> requests.Session:
+    if route_attempt is not None:
+        _mode, trust_env = NETWORK_ROUTE_ATTEMPTS[
+            route_attempt % len(NETWORK_ROUTE_ATTEMPTS)
+        ]
+        return _build_session(trust_env=trust_env)
+
+    session = getattr(_SESSION_LOCAL, "session", None)
+    if session is not None:
+        return session
+
+    session = _build_session()
     _SESSION_LOCAL.session = session
     return session
+
+
+def _request_with_retry(
+    method: str,
+    url: str,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+    session_factory: Callable[[int], requests.Session] = _get_session,
+    _consume: Optional[Callable[[requests.Response], Any]] = None,
+    **kwargs,
+) -> Any:
+    """Run one safe logical request over direct/proxy/direct/proxy."""
+    last_error: Optional[requests.RequestException] = None
+    for attempt in range(len(NETWORK_ROUTE_ATTEMPTS)):
+        if attempt:
+            sleep(NETWORK_RETRY_DELAYS[attempt - 1])
+        response = None
+        try:
+            response = getattr(session_factory(attempt), method.lower())(url, **kwargs)
+            if (
+                response.status_code in NETWORK_RETRYABLE_STATUS_CODES
+                and attempt + 1 < len(NETWORK_ROUTE_ATTEMPTS)
+            ):
+                response.close()
+                continue
+            if _consume is None:
+                return response
+            try:
+                return _consume(response)
+            finally:
+                response.close()
+        except (
+            requests.ConnectionError,
+            requests.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.ContentDecodingError,
+        ) as exc:
+            last_error = exc
+            if response is not None:
+                response.close()
+            if attempt + 1 == len(NETWORK_ROUTE_ATTEMPTS):
+                raise
+            continue
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Request failed without a response")
+
+
+def _post_once(url: str, **kwargs) -> requests.Response:
+    """Send a potentially billable task creation once through direct route."""
+    try:
+        return _get_session(0).post(url, **kwargs)
+    except requests.RequestException as exc:
+        raise RuntimeError(
+            "Submit transport failed after the request may have reached the server; "
+            "it was not retried to avoid a duplicate paid task. Check the provider "
+            f"console before retrying manually: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _checked_content(response: requests.Response, max_bytes: int, label: str) -> bytes:
+    declared = (getattr(response, "headers", {}) or {}).get("Content-Length")
+    if declared:
+        try:
+            if int(declared) > max_bytes:
+                raise RuntimeError(f"{label} exceeds the {max_bytes}-byte limit")
+        except ValueError:
+            pass
+    content = response.content
+    if len(content) > max_bytes:
+        raise RuntimeError(f"{label} exceeds the {max_bytes}-byte limit")
+    if not content:
+        raise RuntimeError(f"{label} is empty")
+    return content
+
+
+def _write_limited(
+    response: requests.Response, path: str, max_bytes: int, label: str
+) -> None:
+    declared = (getattr(response, "headers", {}) or {}).get("Content-Length")
+    if declared:
+        try:
+            if int(declared) > max_bytes:
+                raise RuntimeError(f"{label} exceeds the {max_bytes}-byte limit")
+        except ValueError:
+            pass
+    total = 0
+    try:
+        with open(path, "wb") as handle:
+            for chunk in response.iter_content(chunk_size=65536):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    raise RuntimeError(f"{label} exceeds the {max_bytes}-byte limit")
+                handle.write(chunk)
+        if total <= 0:
+            raise RuntimeError(f"{label} is empty")
+    except Exception:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        raise
 
 
 def _headers(api_key: str, json_content: bool = True) -> Dict[str, str]:
@@ -280,40 +421,22 @@ def upload_media(
     sleep: Callable[[float], None] = time.sleep,
 ) -> str:
     url = f"{config['base_url']}/v1/files/upload"
-    last_error = "unknown error"
-    for attempt in range(5):
-        if attempt:
-            sleep(min(2 ** attempt, 15))
-        try:
-            response = _get_session().post(
-                url,
-                headers=_headers(config["api_key"], json_content=False),
-                files={"file": (filename, file_bytes, mime_type)},
-                timeout=config.get("upload_timeout", 180),
-            )
-        except requests.RequestException as exc:
-            last_error = f"network error: {type(exc).__name__}: {exc}"
-            continue
-
-        data = _response_json(response)
-        message = extract_error_message(data, response.text[:300])
-        if response.status_code == 429:
-            last_error = f"rate limited: {message}"
-            sleep(30)
-            continue
-        if response.status_code >= 500:
-            last_error = f"HTTP {response.status_code}: {message}"
-            continue
-        if not 200 <= response.status_code < 300:
-            raise SeedanceLowPriceError(
-                f"Upload rejected (HTTP {response.status_code}): {message}"
-            )
-        file_url = data.get("url") if isinstance(data, dict) else None
-        if not file_url:
-            last_error = "upload response did not contain url"
-            continue
-        return str(file_url)
-    raise RuntimeError(f"Upload failed after 5 attempts: {last_error}")
+    response = _request_with_retry(
+        "post", url, sleep=sleep,
+        headers=_headers(config["api_key"], json_content=False),
+        files={"file": (filename, file_bytes, mime_type)},
+        timeout=config.get("upload_timeout", 180),
+    )
+    data = _response_json(response)
+    message = extract_error_message(data, response.text[:300])
+    if not 200 <= response.status_code < 300:
+        raise SeedanceLowPriceError(
+            f"Upload rejected (HTTP {response.status_code}): {message}"
+        )
+    file_url = data.get("url") if isinstance(data, dict) else None
+    if not file_url:
+        raise SeedanceLowPriceError("Upload response did not contain url")
+    return str(file_url)
 
 
 def submit_task(
@@ -322,41 +445,20 @@ def submit_task(
     sleep: Callable[[float], None] = time.sleep,
 ) -> Tuple[str, Dict[str, Any]]:
     url = f"{config['base_url']}/v1/videos"
-    last_error = "unknown error"
-    for attempt in range(3):
-        if attempt:
-            sleep(min(2 ** attempt + 1, 15))
-        try:
-            response = _get_session().post(
-                url,
-                headers=_headers(config["api_key"]),
-                json=payload,
-                timeout=config.get("timeout", 60),
-            )
-        except requests.ConnectTimeout as exc:
-            last_error = f"network error: {type(exc).__name__}: {exc}"
-            continue
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                "Submit transport failed after the request may have reached the server; "
-                "it was not retried to avoid creating a duplicate paid task. "
-                f"Check the provider console before retrying manually: {type(exc).__name__}: {exc}"
-            ) from exc
-
-        data = _response_json(response)
-        message = extract_error_message(data, response.text[:300])
-        if response.status_code == 429 or response.status_code >= 500:
-            last_error = f"HTTP {response.status_code}: {message}"
-            continue
-        if not 200 <= response.status_code < 300:
-            raise SeedanceLowPriceError(
-                f"Submit rejected (HTTP {response.status_code}): {message}"
-            )
-        task_id = (data.get("id") or data.get("task_id")) if isinstance(data, dict) else None
-        if not task_id:
-            raise SeedanceLowPriceError("Submit response did not contain id/task_id")
-        return str(task_id), data
-    raise RuntimeError(f"Submit failed after 3 attempts: {last_error}")
+    response = _post_once(
+        url, headers=_headers(config["api_key"]), json=payload,
+        timeout=config.get("timeout", 60),
+    )
+    data = _response_json(response)
+    message = extract_error_message(data, response.text[:300])
+    if not 200 <= response.status_code < 300:
+        raise SeedanceLowPriceError(
+            f"Submit rejected (HTTP {response.status_code}): {message}"
+        )
+    task_id = (data.get("id") or data.get("task_id")) if isinstance(data, dict) else None
+    if not task_id:
+        raise SeedanceLowPriceError("Submit response did not contain id/task_id")
+    return str(task_id), data
 
 
 def _coerce_progress(value: Any) -> Optional[int]:
@@ -381,34 +483,23 @@ def poll_task(
             raise RuntimeError(f"Polling timed out [task_id: {task_id}]")
         sleep(config.get("poll_interval", 4))
         try:
-            response = _get_session().get(
-                url,
+            response = _request_with_retry(
+                "get", url, sleep=sleep,
                 headers=_headers(config["api_key"], json_content=False),
                 timeout=30,
             )
-        except requests.RequestException:
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(f"Polling failed after repeated network errors [task_id: {task_id}]")
-            sleep(min(failures * 2, 10))
-            continue
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Polling failed after 4 route attempts [task_id: {task_id}]"
+            ) from exc
 
         if response.status_code != 200:
             data = _response_json(response)
             message = extract_error_message(data, response.text[:300])
-            if 400 <= response.status_code < 500 and response.status_code not in (408, 429):
-                raise SeedanceLowPriceError(
-                    f"Polling rejected (HTTP {response.status_code}): {message} "
-                    f"[task_id: {task_id}]"
-                )
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(
-                    f"Polling repeatedly returned HTTP {response.status_code}: {message} "
-                    f"[task_id: {task_id}]"
-                )
-            sleep(min(failures * 2, 10))
-            continue
+            raise SeedanceLowPriceError(
+                f"Polling rejected (HTTP {response.status_code}): {message} "
+                f"[task_id: {task_id}]"
+            )
         try:
             data = response.json()
         except ValueError:
@@ -450,7 +541,7 @@ def _video_from_path(path: str) -> Any:
 
 def download_video(
     url: str,
-    max_retries: int = 5,
+    max_retries: int = len(NETWORK_ROUTE_ATTEMPTS),
     attempt_timeout: float = 180.0,
 ) -> Any:
     try:
@@ -461,46 +552,14 @@ def download_video(
         output_dir = os.environ.get("SEEDANCE_OUTPUT_DIR") or tempfile.gettempdir()
     os.makedirs(output_dir, exist_ok=True)
     path = os.path.join(output_dir, f"seedance_low_price_{uuid.uuid4().hex[:12]}.mp4")
-    part_path = f"{path}.part"
-    last_error: Optional[Exception] = None
-    for attempt in range(max_retries):
-        if attempt:
-            time.sleep(2 ** attempt)
-        response = None
-        try:
-            started = time.monotonic()
-            response = _get_session().get(url, stream=True, timeout=(15, 45))
-            response.raise_for_status()
-            with open(part_path, "wb") as handle:
-                for chunk in response.iter_content(chunk_size=65536):
-                    if chunk:
-                        handle.write(chunk)
-                    if time.monotonic() - started > attempt_timeout:
-                        raise TimeoutError(
-                            f"video download exceeded {attempt_timeout:.0f}s attempt limit"
-                        )
-            if not os.path.isfile(part_path) or os.path.getsize(part_path) == 0:
-                raise RuntimeError("downloaded video is empty")
-            os.replace(part_path, path)
-            return _video_from_path(path)
-        except Exception as exc:
-            last_error = exc
-            try:
-                os.remove(part_path)
-            except OSError:
-                pass
-        finally:
-            if response is not None:
-                try:
-                    response.close()
-                except Exception:
-                    pass
-    for candidate in (part_path, path):
-        try:
-            os.remove(candidate)
-        except OSError:
-            pass
-    raise RuntimeError(f"Video download failed after {max_retries} attempts: {last_error}")
+    def consume(response: requests.Response) -> None:
+        response.raise_for_status()
+        _write_limited(response, path, VIDEO_DOWNLOAD_MAX_BYTES, "video download")
+
+    _request_with_retry(
+        "get", url, _consume=consume, stream=True, timeout=300
+    )
+    return _video_from_path(path)
 
 
 def image_to_png_bytes(image: Any) -> bytes:
@@ -1439,46 +1498,24 @@ def submit_image_task(
     sleep: Callable[[float], None] = time.sleep,
 ) -> Tuple[str, Dict[str, Any]]:
     url = f"{config['base_url']}/v1/image/generations"
-    last_error = "unknown error"
-    for attempt in range(3):
-        if attempt:
-            sleep(min(2 ** attempt + 1, 15))
-        try:
-            response = _get_session().post(
-                url,
-                headers=_headers(config["api_key"]),
-                json=payload,
-                timeout=config.get("timeout", 60),
-            )
-        except requests.ConnectTimeout as exc:
-            last_error = f"network error: {type(exc).__name__}: {exc}"
-            continue
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                "Seedream submit transport failed after the request may have reached the server; "
-                "it was not retried to avoid a duplicate paid task. Check the provider console "
-                f"before retrying manually: {type(exc).__name__}: {exc}"
-            ) from exc
-
-        data = _response_json(response)
-        message = extract_error_message(data, response.text[:300])
-        if response.status_code == 429 or response.status_code >= 500:
-            last_error = f"HTTP {response.status_code}: {message}"
-            continue
-        if not 200 <= response.status_code < 300:
-            raise SeedanceLowPriceError(
-                f"Seedream submit rejected (HTTP {response.status_code}): {message}"
-            )
-
-        task_id = None
-        if isinstance(data, dict):
-            task_id = data.get("task_id") or data.get("id")
-            if not task_id and isinstance(data.get("data"), dict):
-                task_id = data["data"].get("task_id") or data["data"].get("id")
-        if not task_id:
-            raise SeedanceLowPriceError("Seedream submit response did not contain task_id/id")
-        return str(task_id), data
-    raise RuntimeError(f"Seedream submit failed after 3 attempts: {last_error}")
+    response = _post_once(
+        url, headers=_headers(config["api_key"]), json=payload,
+        timeout=config.get("timeout", 60),
+    )
+    data = _response_json(response)
+    message = extract_error_message(data, response.text[:300])
+    if not 200 <= response.status_code < 300:
+        raise SeedanceLowPriceError(
+            f"Seedream submit rejected (HTTP {response.status_code}): {message}"
+        )
+    task_id = None
+    if isinstance(data, dict):
+        task_id = data.get("task_id") or data.get("id")
+        if not task_id and isinstance(data.get("data"), dict):
+            task_id = data["data"].get("task_id") or data["data"].get("id")
+    if not task_id:
+        raise SeedanceLowPriceError("Seedream submit response did not contain task_id/id")
+    return str(task_id), data
 
 
 def poll_image_task(
@@ -1496,36 +1533,23 @@ def poll_image_task(
             raise RuntimeError(f"Seedream polling timed out [task_id: {task_id}]")
         sleep(config.get("poll_interval", 4))
         try:
-            response = _get_session().get(
-                url,
+            response = _request_with_retry(
+                "get", url, sleep=sleep,
                 headers=_headers(config["api_key"], json_content=False),
                 timeout=30,
             )
-        except requests.RequestException:
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(
-                    f"Seedream polling failed after repeated network errors [task_id: {task_id}]"
-                )
-            sleep(min(failures * 2, 10))
-            continue
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Seedream polling failed after 4 route attempts [task_id: {task_id}]"
+            ) from exc
 
         if response.status_code != 200:
             data = _response_json(response)
             message = extract_error_message(data, response.text[:300])
-            if 400 <= response.status_code < 500 and response.status_code not in (408, 429):
-                raise SeedanceLowPriceError(
-                    f"Seedream polling rejected (HTTP {response.status_code}): {message} "
-                    f"[task_id: {task_id}]"
-                )
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(
-                    f"Seedream polling repeatedly returned HTTP {response.status_code}: {message} "
-                    f"[task_id: {task_id}]"
-                )
-            sleep(min(failures * 2, 10))
-            continue
+            raise SeedanceLowPriceError(
+                f"Seedream polling rejected (HTTP {response.status_code}): {message} "
+                f"[task_id: {task_id}]"
+            )
 
         try:
             result = response.json()
@@ -1602,19 +1626,19 @@ def _pil_to_image_tensor(image: Image.Image) -> torch.Tensor:
     return torch.from_numpy(array).unsqueeze(0)
 
 
-def download_image(url: str, max_retries: int = 3) -> torch.Tensor:
-    last_error: Optional[Exception] = None
-    for attempt in range(max_retries):
-        if attempt:
-            time.sleep(2 ** attempt)
-        try:
-            response = _get_session().get(url, timeout=300)
-            response.raise_for_status()
-            with Image.open(io.BytesIO(response.content)) as image:
-                return _pil_to_image_tensor(image)
-        except Exception as exc:
-            last_error = exc
-    raise RuntimeError(f"Seedream image download failed after {max_retries} attempts: {last_error}")
+def download_image(
+    url: str,
+    max_retries: int = len(NETWORK_ROUTE_ATTEMPTS),
+) -> torch.Tensor:
+    def consume(response: requests.Response) -> bytes:
+        response.raise_for_status()
+        return _checked_content(
+            response, IMAGE_DOWNLOAD_MAX_BYTES, "image download"
+        )
+
+    content = _request_with_retry("get", url, _consume=consume, timeout=300)
+    with Image.open(io.BytesIO(content)) as image:
+        return _pil_to_image_tensor(image)
 
 
 def download_image_with_mask(url: str) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -5418,52 +5442,29 @@ def submit_audio_task(
     sleep: Callable[[float], None] = time.sleep,
 ) -> Tuple[str, Dict[str, Any]]:
     url = f"{config['base_url']}/v1/audio/generations"
-    last_error = "unknown error"
-    for attempt in range(3):
-        if attempt:
-            sleep(min(2 ** attempt + 1, 15))
-        try:
-            response = _get_session().post(
-                url,
-                headers=_headers(config["api_key"]),
-                json=payload,
-                timeout=config.get("timeout", 60),
-            )
-        except requests.ConnectTimeout as exc:
-            last_error = f"network error: {type(exc).__name__}: {exc}"
-            continue
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                "Seed Audio submit transport failed after the request may have reached "
-                "the server; it was not retried to avoid a duplicate paid task. "
-                f"Check the provider console before retrying manually: {type(exc).__name__}: {exc}"
-            ) from exc
-
-        data = _response_json(response)
-        message = extract_error_message(data, response.text[:300])
-        if response.status_code == 429 or response.status_code >= 500:
-            last_error = f"HTTP {response.status_code}: {message}"
-            continue
-        if not 200 <= response.status_code < 300:
-            if response.status_code == 404 and "invalid url" in message.lower():
-                raise SeedanceLowPriceError(
-                    "Seed Audio provider route is not enabled yet: the documented "
-                    f"POST /v1/audio/generations returned HTTP 404 ({message})"
-                )
+    response = _post_once(
+        url, headers=_headers(config["api_key"]), json=payload,
+        timeout=config.get("timeout", 60),
+    )
+    data = _response_json(response)
+    message = extract_error_message(data, response.text[:300])
+    if not 200 <= response.status_code < 300:
+        if response.status_code == 404 and "invalid url" in message.lower():
             raise SeedanceLowPriceError(
-                f"Seed Audio submit rejected (HTTP {response.status_code}): {message}"
+                "Seed Audio provider route is not enabled yet: the documented "
+                f"POST /v1/audio/generations returned HTTP 404 ({message})"
             )
-        task_id = None
-        if isinstance(data, dict):
-            task_id = data.get("task_id") or data.get("id")
-            if not task_id and isinstance(data.get("data"), dict):
-                task_id = data["data"].get("task_id") or data["data"].get("id")
-        if not task_id:
-            raise SeedanceLowPriceError(
-                "Seed Audio submit response did not contain task_id/id"
-            )
-        return str(task_id), data
-    raise RuntimeError(f"Seed Audio submit failed after 3 attempts: {last_error}")
+        raise SeedanceLowPriceError(
+            f"Seed Audio submit rejected (HTTP {response.status_code}): {message}"
+        )
+    task_id = None
+    if isinstance(data, dict):
+        task_id = data.get("task_id") or data.get("id")
+        if not task_id and isinstance(data.get("data"), dict):
+            task_id = data["data"].get("task_id") or data["data"].get("id")
+    if not task_id:
+        raise SeedanceLowPriceError("Seed Audio submit response did not contain task_id/id")
+    return str(task_id), data
 
 
 def poll_audio_task(
@@ -5481,36 +5482,23 @@ def poll_audio_task(
             raise RuntimeError(f"Seed Audio polling timed out [task_id: {task_id}]")
         sleep(config.get("poll_interval", 4))
         try:
-            response = _get_session().get(
-                url,
+            response = _request_with_retry(
+                "get", url, sleep=sleep,
                 headers=_headers(config["api_key"], json_content=False),
                 timeout=30,
             )
-        except requests.RequestException:
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(
-                    f"Seed Audio polling failed after repeated network errors [task_id: {task_id}]"
-                )
-            sleep(min(failures * 2, 10))
-            continue
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Seed Audio polling failed after 4 route attempts [task_id: {task_id}]"
+            ) from exc
 
         data = _response_json(response)
         message = extract_error_message(data, response.text[:300])
         if response.status_code != 200:
-            if 400 <= response.status_code < 500 and response.status_code not in (408, 429):
-                raise SeedanceLowPriceError(
-                    f"Seed Audio polling rejected (HTTP {response.status_code}): {message} "
-                    f"[task_id: {task_id}]"
-                )
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(
-                    f"Seed Audio polling repeatedly returned HTTP {response.status_code}: "
-                    f"{message} [task_id: {task_id}]"
-                )
-            sleep(min(failures * 2, 10))
-            continue
+            raise SeedanceLowPriceError(
+                f"Seed Audio polling rejected (HTTP {response.status_code}): {message} "
+                f"[task_id: {task_id}]"
+            )
 
         failures = 0
         record = data.get("data") if isinstance(data, dict) else None
@@ -5631,22 +5619,19 @@ def download_audio(
     url: str,
     output_format: str,
     expected_sample_rate: int,
-    max_retries: int = 3,
+    max_retries: int = len(NETWORK_ROUTE_ATTEMPTS),
 ) -> Dict[str, Any]:
-    last_error: Optional[Exception] = None
-    for attempt in range(max_retries):
-        if attempt:
-            time.sleep(2 ** attempt)
-        try:
-            response = _get_session().get(url, timeout=300)
-            response.raise_for_status()
-            return audio_bytes_to_comfy(
-                response.content, output_format, expected_sample_rate
-            )
-        except Exception as exc:
-            last_error = exc
-    raise RuntimeError(
-        f"Seed Audio download failed after {max_retries} attempts: {last_error}"
+    def consume(response: requests.Response) -> bytes:
+        response.raise_for_status()
+        return _checked_content(
+            response, AUDIO_DOWNLOAD_MAX_BYTES, "audio download"
+        )
+
+    content = _request_with_retry("get", url, _consume=consume, timeout=300)
+    return audio_bytes_to_comfy(
+        content,
+        output_format,
+        expected_sample_rate,
     )
 
 
@@ -7785,48 +7770,32 @@ def transcribe_audio(
     url = f"{config['base_url']}/v1/audio/transcriptions"
     form = {"model": model, "response_format": response_format}
     files = {"file": (filename, file_bytes, mime_type)}
-    last_error = "unknown error"
-    for attempt in range(3):
-        if attempt:
-            sleep(min(2 ** attempt + 1, 15))
-        try:
-            response = _get_session().post(
-                url,
-                headers=_headers(config["api_key"], json_content=False),
-                data=form,
-                files=files,
-                timeout=config.get("timeout", 60),
-            )
-        except requests.RequestException as exc:
-            last_error = f"network error: {type(exc).__name__}: {exc}"
-            continue
-
-        try:
-            parsed = response.json() if response.text else None
-        except ValueError:
-            parsed = None
-        if response.status_code == 429 or response.status_code >= 500:
-            last_error = (
-                f"HTTP {response.status_code}: "
-                f"{extract_error_message(parsed, response.text[:300])}"
-            )
-            continue
-        if not 200 <= response.status_code < 300:
+    response = _post_once(
+        url,
+        headers=_headers(config["api_key"], json_content=False),
+        data=form,
+        files=files,
+        timeout=config.get("timeout", 60),
+    )
+    try:
+        parsed = response.json() if response.text else None
+    except ValueError:
+        parsed = None
+    if not 200 <= response.status_code < 300:
+        raise SeedanceLowPriceError(
+            f"Transcription rejected (HTTP {response.status_code}): "
+            f"{extract_error_message(parsed, response.text[:300])}"
+        )
+    if response_format in ("json", "verbose_json"):
+        if not isinstance(parsed, dict):
             raise SeedanceLowPriceError(
-                f"Transcription rejected (HTTP {response.status_code}): "
-                f"{extract_error_message(parsed, response.text[:300])}"
+                f"Transcription returned invalid JSON: {response.text[:300]}"
             )
-        if response_format in ("json", "verbose_json"):
-            if not isinstance(parsed, dict):
-                raise SeedanceLowPriceError(
-                    f"Transcription returned invalid JSON: {response.text[:300]}"
-                )
-            return (
-                _extract_transcription_text(parsed),
-                json.dumps(parsed, ensure_ascii=False, indent=2),
-            )
-        return (response.text, response.text)
-    raise RuntimeError(f"Transcription failed after 3 attempts: {last_error}")
+        return (
+            _extract_transcription_text(parsed),
+            json.dumps(parsed, ensure_ascii=False, indent=2),
+        )
+    return (response.text, response.text)
 
 
 class Comfly_whisper_1_lowprice:
@@ -8267,40 +8236,19 @@ def submit_suno_action(
     action_text = str(action or "").strip().strip("/")
     suffix = f"/{action_text}" if action_text else ""
     url = f"{config['base_url']}/v1/music/generations{suffix}"
-    last_error = "unknown error"
-    for attempt in range(3):
-        if attempt:
-            sleep(min(2 ** attempt + 1, 15))
-        try:
-            response = _get_session().post(
-                url,
-                headers=_headers(config["api_key"]),
-                json=payload,
-                timeout=config.get("timeout", 60),
-            )
-        except requests.ConnectTimeout as exc:
-            last_error = f"network error: {type(exc).__name__}: {exc}"
-            continue
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                "Suno submit transport failed after the request may have reached "
-                "the server; it was not retried to avoid a duplicate paid task. "
-                f"Check the provider console before retrying: {type(exc).__name__}: {exc}"
-            ) from exc
-
-        data = _response_json(response)
-        message = extract_error_message(data, response.text[:300])
-        if response.status_code == 429 or response.status_code >= 500:
-            last_error = f"HTTP {response.status_code}: {message}"
-            continue
-        if not 200 <= response.status_code < 300:
-            raise SeedanceLowPriceError(
-                f"Suno submit rejected (HTTP {response.status_code}): {message}"
-            )
-        if not isinstance(data, dict):
-            raise SeedanceLowPriceError("Suno submit returned a non-object JSON response")
-        return _extract_suno_task_id(data), data
-    raise RuntimeError(f"Suno submit failed after 3 attempts: {last_error}")
+    response = _post_once(
+        url, headers=_headers(config["api_key"]), json=payload,
+        timeout=config.get("timeout", 60),
+    )
+    data = _response_json(response)
+    message = extract_error_message(data, response.text[:300])
+    if not 200 <= response.status_code < 300:
+        raise SeedanceLowPriceError(
+            f"Suno submit rejected (HTTP {response.status_code}): {message}"
+        )
+    if not isinstance(data, dict):
+        raise SeedanceLowPriceError("Suno submit returned a non-object JSON response")
+    return _extract_suno_task_id(data), data
 
 
 def poll_suno_task(
@@ -8321,32 +8269,20 @@ def poll_suno_task(
             raise RuntimeError("Suno polling timed out")
         sleep(config.get("poll_interval", 4))
         try:
-            response = _get_session().get(
-                url,
+            response = _request_with_retry(
+                "get", url, sleep=sleep,
                 headers=_headers(config["api_key"], json_content=False),
                 timeout=30,
             )
-        except requests.RequestException:
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError("Suno polling failed after repeated network errors")
-            sleep(min(failures * 2, 10))
-            continue
+        except requests.RequestException as exc:
+            raise RuntimeError("Suno polling failed after 4 route attempts") from exc
 
         data = _response_json(response)
         message = extract_error_message(data, response.text[:300])
         if response.status_code != 200:
-            if 400 <= response.status_code < 500 and response.status_code not in (408, 429):
-                raise SeedanceLowPriceError(
-                    f"Suno polling rejected (HTTP {response.status_code}): {message}"
-                )
-            failures += 1
-            if failures >= 6:
-                raise RuntimeError(
-                    f"Suno polling repeatedly returned HTTP {response.status_code}: {message}"
-                )
-            sleep(min(failures * 2, 10))
-            continue
+            raise SeedanceLowPriceError(
+                f"Suno polling rejected (HTTP {response.status_code}): {message}"
+            )
         if not isinstance(data, dict):
             failures += 1
             if failures >= 6:
@@ -8533,43 +8469,28 @@ def download_suno_file(
     url: str,
     filename_prefix: str,
     fallback_extension: str,
-    max_retries: int = 3,
+    max_retries: int = len(NETWORK_ROUTE_ATTEMPTS),
 ) -> str:
     output_dir = _suno_output_directory()
-    last_error: Optional[Exception] = None
-    for attempt in range(max_retries):
-        if attempt:
-            time.sleep(2 ** attempt)
-        path = ""
-        try:
-            response = _get_session().get(url, stream=True, timeout=300)
-            response.raise_for_status()
-            content_type = (getattr(response, "headers", {}) or {}).get(
-                "Content-Type", ""
-            )
-            extension = _guess_suno_extension(
-                url, content_type, fallback_extension
-            )
-            path = os.path.join(
-                output_dir,
-                f"{filename_prefix}_{uuid.uuid4().hex[:12]}{extension}",
-            )
-            with open(path, "wb") as handle:
-                for chunk in response.iter_content(chunk_size=65536):
-                    if chunk:
-                        handle.write(chunk)
-            if os.path.getsize(path) <= 0:
-                raise RuntimeError("downloaded file is empty")
-            return path
-        except Exception as exc:
-            last_error = exc
-            if path:
-                try:
-                    os.remove(path)
-                except OSError:
-                    pass
-    raise RuntimeError(
-        f"Suno result download failed after {max_retries} attempts: {last_error}"
+    max_bytes = VIDEO_DOWNLOAD_MAX_BYTES if fallback_extension == "mp4" else AUDIO_DOWNLOAD_MAX_BYTES
+
+    def consume(response: requests.Response) -> str:
+        response.raise_for_status()
+        content_type = (getattr(response, "headers", {}) or {}).get(
+            "Content-Type", ""
+        )
+        extension = _guess_suno_extension(
+            url, content_type, fallback_extension
+        )
+        path = os.path.join(
+            output_dir,
+            f"{filename_prefix}_{uuid.uuid4().hex[:12]}{extension}",
+        )
+        _write_limited(response, path, max_bytes, "Suno result download")
+        return path
+
+    return _request_with_retry(
+        "get", url, _consume=consume, stream=True, timeout=300
     )
 
 

--- a/t8star_http.py
+++ b/t8star_http.py
@@ -1,0 +1,319 @@
+"""Route-isolated HTTP retry policy for safe external requests."""
+
+import asyncio
+import os
+import time
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+
+
+T8STAR_ROUTE_ATTEMPTS = (
+    ("direct", False),
+    ("proxy", True),
+    ("direct", False),
+    ("proxy", True),
+)
+T8STAR_RETRY_DELAYS = (1, 5, 10)
+T8STAR_RETRYABLE_STATUS_CODES = frozenset({429, 502, 503, 504})
+T8STAR_IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+T8STAR_RETRYABLE_NETWORK_ERRORS = (
+    requests.ConnectionError,
+    requests.Timeout,
+    requests.exceptions.ChunkedEncodingError,
+    requests.exceptions.ContentDecodingError,
+)
+DEFAULT_MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
+DEFAULT_TIMEOUT = (15, 120)
+
+
+def _url_without_query(url: str) -> str:
+    parsed = urlsplit(url)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+
+def create_alternating_route_session(route_attempt: int) -> requests.Session:
+    """Create one isolated session for a caller-owned retry loop."""
+    _mode, trust_env = T8STAR_ROUTE_ATTEMPTS[
+        route_attempt % len(T8STAR_ROUTE_ATTEMPTS)
+    ]
+    session = requests.Session()
+    session.trust_env = trust_env
+    return session
+
+
+def _rewind_files(files) -> None:
+    if not files:
+        return
+    values = files.values() if isinstance(files, dict) else files
+    for item in values:
+        candidate = item
+        if isinstance(item, tuple):
+            candidate = next(
+                (part for part in item if hasattr(part, "seek")), None
+            )
+        if hasattr(candidate, "seek"):
+            candidate.seek(0)
+
+
+class T8StarRouteSession:
+    """Small requests-compatible client with fixed route alternation.
+
+    Idempotent requests start with a fresh direct session. Transient transport
+    failures and HTTP 429/502/503/504 then use proxy, direct, and proxy in that
+    order, waiting 1/5/10 seconds. Paid or otherwise non-idempotent requests
+    are sent once through the direct route so an ambiguous response cannot
+    create duplicate work. Environment proxy variables are never changed.
+    """
+
+    def request(self, method: str, url: str, **kwargs):
+        normalized_method = method.upper()
+        consume = kwargs.pop("_consume", None)
+        if normalized_method not in T8STAR_IDEMPOTENT_METHODS:
+            with create_alternating_route_session(0) as session:
+                return session.request(normalized_method, url, **kwargs)
+
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+
+        safe_url = _url_without_query(url)
+        last_error = None
+        last_response = None
+
+        for attempt, (mode, trust_env) in enumerate(
+            T8STAR_ROUTE_ATTEMPTS, start=1
+        ):
+            if attempt > 1:
+                time.sleep(T8STAR_RETRY_DELAYS[attempt - 2])
+            try:
+                with create_alternating_route_session(attempt - 1) as session:
+                    response = session.request(normalized_method, url, **kwargs)
+                    last_error = None
+                    if response.status_code not in T8STAR_RETRYABLE_STATUS_CODES:
+                        if consume is None:
+                            return response
+                        try:
+                            return consume(response)
+                        finally:
+                            response.close()
+
+                    last_response = response
+                    print(
+                        f"[t8star] HTTP {response.status_code} for {safe_url} "
+                        f"(attempt {attempt}/{len(T8STAR_ROUTE_ATTEMPTS)}, "
+                        f"mode={mode})"
+                    )
+            except T8STAR_RETRYABLE_NETWORK_ERRORS as error:
+                last_error = error
+                print(
+                    f"[t8star] Request failed for {safe_url} "
+                    f"(attempt {attempt}/{len(T8STAR_ROUTE_ATTEMPTS)}, "
+                    f"mode={mode}): {type(error).__name__}"
+                )
+
+        if last_error is not None:
+            raise last_error
+        if consume is not None and last_response is not None:
+            last_response.raise_for_status()
+        return last_response
+
+    def get(self, url: str, **kwargs):
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs):
+        return self.request("POST", url, **kwargs)
+
+    def close(self):
+        return None
+
+
+def create_t8star_session() -> T8StarRouteSession:
+    return T8StarRouteSession()
+
+
+def safe_get(url: str, **kwargs):
+    return create_t8star_session().get(url, **kwargs)
+
+
+def safe_get_content(
+    url: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_DOWNLOAD_BYTES,
+    chunk_size: int = 64 * 1024,
+    **kwargs,
+) -> bytes:
+    """Read a complete GET body inside the four-route retry boundary."""
+    kwargs.pop("stream", None)
+
+    def consume(response):
+        response.raise_for_status()
+        content_length = response.headers.get("Content-Length", "")
+        if content_length.isdigit() and int(content_length) > max_bytes:
+            raise ValueError(f"remote file exceeds {max_bytes} bytes")
+        body = bytearray()
+        for chunk in response.iter_content(chunk_size=chunk_size):
+            if chunk:
+                body.extend(chunk)
+                if len(body) > max_bytes:
+                    raise ValueError(f"remote file exceeds {max_bytes} bytes")
+        return bytes(body)
+
+    return create_t8star_session().request(
+        "GET", url, _consume=consume, stream=True, **kwargs
+    )
+
+
+def safe_download_to_path(
+    url: str,
+    output_path: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_DOWNLOAD_BYTES,
+    chunk_size: int = 64 * 1024,
+    **kwargs,
+) -> int:
+    """Download from byte zero after a retryable TLS/stream interruption."""
+    kwargs.pop("stream", None)
+
+    def consume(response):
+        response.raise_for_status()
+        content_length = response.headers.get("Content-Length", "")
+        if content_length.isdigit() and int(content_length) > max_bytes:
+            raise ValueError(f"remote file exceeds {max_bytes} bytes")
+        total = 0
+        with open(output_path, "wb") as output:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError(f"remote file exceeds {max_bytes} bytes")
+                output.write(chunk)
+        return total
+
+    try:
+        return create_t8star_session().request(
+            "GET", url, _consume=consume, stream=True, **kwargs
+        )
+    except Exception:
+        if os.path.exists(output_path):
+            os.remove(output_path)
+        raise
+
+
+def safe_upload_post(url: str, **kwargs):
+    """Retry an explicitly non-billable upload POST over all four routes."""
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    safe_url = _url_without_query(url)
+    last_error = None
+    last_response = None
+    for attempt, (mode, _trust_env) in enumerate(T8STAR_ROUTE_ATTEMPTS):
+        if attempt > 0:
+            time.sleep(T8STAR_RETRY_DELAYS[attempt - 1])
+        _rewind_files(kwargs.get("files"))
+        try:
+            with create_alternating_route_session(attempt) as session:
+                response = session.post(url, **kwargs)
+                last_error = None
+                if response.status_code not in T8STAR_RETRYABLE_STATUS_CODES:
+                    return response
+                last_response = response
+                print(
+                    f"[t8star] Upload HTTP {response.status_code} for {safe_url} "
+                    f"(attempt {attempt + 1}/4, mode={mode})"
+                )
+                if attempt + 1 < len(T8STAR_ROUTE_ATTEMPTS):
+                    response.close()
+        except T8STAR_RETRYABLE_NETWORK_ERRORS as error:
+            last_error = error
+            print(
+                f"[t8star] Upload failed for {safe_url} "
+                f"(attempt {attempt + 1}/4, mode={mode}): "
+                f"{type(error).__name__}"
+            )
+    if last_error is not None:
+        raise last_error
+    return last_response
+
+
+def safe_idempotent_post(url: str, **kwargs):
+    """Retry a documented non-billable, idempotent POST over all routes."""
+    return safe_upload_post(url, **kwargs)
+
+
+def safe_chat_post(url: str, **kwargs):
+    """Retry synchronous chat POSTs with an explicit duplicate-billing risk."""
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    safe_url = _url_without_query(url)
+    last_error = None
+    last_response = None
+    for attempt, (mode, _trust_env) in enumerate(T8STAR_ROUTE_ATTEMPTS):
+        if attempt > 0:
+            time.sleep(T8STAR_RETRY_DELAYS[attempt - 1])
+        response = None
+        try:
+            with create_alternating_route_session(attempt) as session:
+                response = session.post(url, **kwargs)
+                last_error = None
+                if response.status_code not in T8STAR_RETRYABLE_STATUS_CODES:
+                    if kwargs.get("stream"):
+                        # Read the complete SSE body while failures can still
+                        # switch routes and replay the chat request.
+                        _ = response.content
+                    return response
+                last_response = response
+                print(
+                    f"[t8star] Chat HTTP {response.status_code} for {safe_url} "
+                    f"(attempt {attempt + 1}/4, mode={mode}); "
+                    "duplicate chat billing is possible"
+                )
+                if attempt + 1 < len(T8STAR_ROUTE_ATTEMPTS):
+                    response.close()
+        except T8STAR_RETRYABLE_NETWORK_ERRORS as error:
+            last_error = error
+            if response is not None:
+                response.close()
+            print(
+                f"[t8star] Chat failed for {safe_url} "
+                f"(attempt {attempt + 1}/4, mode={mode}): "
+                f"{type(error).__name__}; duplicate chat billing is possible"
+            )
+    if last_error is not None:
+        raise last_error
+    return last_response
+
+
+class _AsyncResponseAdapter:
+    def __init__(self, response):
+        self._response = response
+        self.status = response.status_code
+
+    async def json(self):
+        return self._response.json()
+
+    async def text(self):
+        return self._response.text
+
+
+class _AsyncSafeGetContext:
+    def __init__(self, url, kwargs, caller=safe_get):
+        self.url = url
+        self.kwargs = kwargs
+        self.caller = caller
+        self.response = None
+
+    async def __aenter__(self):
+        self.response = await asyncio.to_thread(
+            self.caller, self.url, **self.kwargs
+        )
+        return _AsyncResponseAdapter(self.response)
+
+    async def __aexit__(self, _exc_type, _exc, _traceback):
+        if self.response is not None:
+            self.response.close()
+
+
+def async_safe_get(url: str, **kwargs):
+    return _AsyncSafeGetContext(url, kwargs)
+
+
+def async_safe_upload_post(url: str, **kwargs):
+    return _AsyncSafeGetContext(url, kwargs, caller=safe_upload_post)

--- a/tests/test_media_download.py
+++ b/tests/test_media_download.py
@@ -1,0 +1,92 @@
+import io
+import unittest
+from unittest.mock import patch
+
+import requests
+from PIL import Image
+
+import media_download
+
+
+def png_bytes():
+    buffer = io.BytesIO()
+    Image.new("RGBA", (2, 1), (255, 0, 0, 128)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+class FakeResponse:
+    def __init__(self, status=200, content=b"", error=None):
+        self.status_code = status
+        self._content = content
+        self.error = error
+        self.closed = False
+
+    @property
+    def content(self):
+        if self.error:
+            raise self.error
+        return self._content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSession:
+    def __init__(self, route, response):
+        self.route = route
+        self.response = response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def get(self, *_args, **_kwargs):
+        return self.response
+
+
+class MediaDownloadRetryTests(unittest.TestCase):
+    def test_tls_eof_uses_all_routes_and_fixed_waits(self):
+        responses = [
+            FakeResponse(error=requests.exceptions.SSLError("EOF")),
+            FakeResponse(error=requests.exceptions.ChunkedEncodingError("EOF")),
+            FakeResponse(status=503),
+            FakeResponse(content=png_bytes()),
+        ]
+        routes = []
+
+        def session_for(attempt):
+            routes.append(media_download.T8STAR_ROUTE_ATTEMPTS[attempt][0])
+            return FakeSession(attempt, responses[attempt])
+
+        with patch.object(media_download, "create_alternating_route_session", side_effect=session_for), patch.object(
+            media_download.time, "sleep"
+        ) as sleep:
+            image = media_download.download_image_with_alpha_retry("https://cdn.test/layer.png")
+
+        self.assertEqual(image.mode, "RGBA")
+        self.assertEqual(routes, ["direct", "proxy", "direct", "proxy"])
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1, 5, 10])
+        self.assertTrue(all(response.closed for response in responses))
+
+    def test_business_404_is_not_retried(self):
+        calls = []
+
+        def session_for(attempt):
+            calls.append(attempt)
+            return FakeSession(attempt, FakeResponse(status=404))
+
+        with patch.object(media_download, "create_alternating_route_session", side_effect=session_for):
+            with self.assertRaises(requests.HTTPError):
+                media_download.download_image_with_retry("https://cdn.test/missing.png")
+
+        self.assertEqual(calls, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_route_retry.py
+++ b/tests/test_route_retry.py
@@ -1,0 +1,274 @@
+import ast
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import midjourney_low_price_nodes as midjourney
+import seedance_low_price_nodes as seedance
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, chunks=()):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = "{}"
+        self.headers = {}
+        self.chunks = chunks
+        self.closed = False
+
+    def json(self):
+        return self._payload
+
+    def close(self):
+        self.closed = True
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise seedance.requests.HTTPError(
+                f"HTTP {self.status_code}", response=self
+            )
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        for chunk in self.chunks:
+            if isinstance(chunk, Exception):
+                raise chunk
+            yield chunk
+
+
+class RouteRetryTests(unittest.TestCase):
+    def test_safe_request_runs_all_routes_with_fixed_waits(self):
+        outcomes = iter([
+            seedance.requests.ConnectionError("direct"),
+            FakeResponse(503),
+            FakeResponse(502),
+            FakeResponse(200),
+        ])
+        routes = []
+        sleeps = []
+
+        class Session:
+            def get(self, _url, **_kwargs):
+                outcome = next(outcomes)
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return outcome
+
+        response = seedance._request_with_retry(
+            "get",
+            "https://api.seedance.nz/v1/tasks/1",
+            sleep=sleeps.append,
+            session_factory=lambda attempt: routes.append(attempt) or Session(),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(routes, [0, 1, 2, 3])
+        self.assertEqual(sleeps, [1, 5, 10])
+
+    def test_http_500_is_not_retried(self):
+        routes = []
+
+        class Session:
+            def get(self, _url, **_kwargs):
+                return FakeResponse(500)
+
+        response = seedance._request_with_retry(
+            "get",
+            "https://api.seedance.nz/v1/tasks/1",
+            session_factory=lambda attempt: routes.append(attempt) or Session(),
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(routes, [0])
+
+    def test_stream_tls_eof_is_retried_inside_consumer_boundary(self):
+        outcomes = iter(
+            [
+                FakeResponse(
+                    chunks=(
+                        b"partial",
+                        seedance.requests.exceptions.SSLError("TLS EOF"),
+                    )
+                ),
+                FakeResponse(chunks=(b"complete", b"-body")),
+            ]
+        )
+        routes = []
+        sleeps = []
+
+        class Session:
+            def get(self, _url, **_kwargs):
+                return next(outcomes)
+
+        def consume(response):
+            return b"".join(response.iter_content(chunk_size=64))
+
+        body = seedance._request_with_retry(
+            "get",
+            "https://cdn.example.test/result.bin",
+            sleep=sleeps.append,
+            session_factory=lambda attempt: routes.append(attempt) or Session(),
+            _consume=consume,
+            stream=True,
+        )
+
+        self.assertEqual(body, b"complete-body")
+        self.assertEqual(routes, [0, 1])
+        self.assertEqual(sleeps, [1])
+
+    def test_paid_submit_is_sent_once(self):
+        response = FakeResponse(200, {"id": "task-1"})
+        with mock.patch.object(seedance, "_post_once", return_value=response) as post:
+            task_id, _ = seedance.submit_task(
+                {"model": "seedance"},
+                {"base_url": "https://api.seedance.nz", "api_key": "sk-test"},
+            )
+
+        self.assertEqual(task_id, "task-1")
+        post.assert_called_once()
+
+    def test_credentials_do_not_fall_back_to_environment(self):
+        with mock.patch.dict(
+            os.environ,
+            {"SEEDANCE_API_KEY": "sk-environment-secret"},
+            clear=False,
+        ):
+            with self.assertRaises(seedance.SeedanceLowPriceError):
+                seedance.resolve_config(None)
+
+    def test_seedance_retry_sessions_follow_fixed_route_order(self):
+        with mock.patch.object(
+            seedance,
+            "_build_session",
+            side_effect=lambda trust_env=True: trust_env,
+        ) as build_session:
+            routes = [seedance._get_session(attempt) for attempt in range(4)]
+
+        self.assertEqual(routes, [False, True, False, True])
+        self.assertEqual(
+            [call.kwargs["trust_env"] for call in build_session.call_args_list],
+            [False, True, False, True],
+        )
+
+    def test_midjourney_retry_sessions_follow_fixed_route_order(self):
+        with mock.patch.object(
+            midjourney,
+            "_build_session",
+            side_effect=lambda trust_env=True: trust_env,
+        ) as build_session:
+            routes = [
+                midjourney._midjourney_session(attempt)
+                for attempt in range(4)
+            ]
+
+        self.assertEqual(routes, [False, True, False, True])
+        self.assertEqual(
+            [call.kwargs["trust_env"] for call in build_session.call_args_list],
+            [False, True, False, True],
+        )
+
+    def test_nodes_with_retry_widgets_use_caller_owned_route_attempts(self):
+        source_path = Path(__file__).resolve().parents[1] / "Comfly.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        target_classes = {
+            "Comfly_kling_multi_image2video",
+            "Comfly_gpt_image_1_edit",
+            "Comfly_gpt_image_2_official",
+            "Comfly_gpt_image_2_official_ratio",
+            "Comfly_gpt_image_2_official_ratio_stable",
+        }
+
+        checked = set()
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef) or node.name not in target_classes:
+                continue
+            retry_method = next(
+                child
+                for child in node.body
+                if isinstance(child, ast.FunctionDef)
+                and child.name == "make_request_with_retry"
+            )
+            calls = [
+                child
+                for child in ast.walk(retry_method)
+                if isinstance(child, ast.Call)
+            ]
+            self.assertTrue(
+                any(
+                    isinstance(call.func, ast.Name)
+                    and call.func.id == "create_alternating_route_session"
+                    for call in calls
+                ),
+                node.name,
+            )
+            self.assertFalse(
+                any(
+                    isinstance(call.func, ast.Attribute)
+                    and isinstance(call.func.value, ast.Attribute)
+                    and isinstance(call.func.value.value, ast.Name)
+                    and call.func.value.value.id == "self"
+                    and call.func.value.attr == "session"
+                    for call in calls
+                ),
+                node.name,
+            )
+            checked.add(node.name)
+
+        self.assertEqual(checked, target_classes)
+
+    def test_submit_retry_widget_is_decoupled_from_result_downloads(self):
+        source_path = Path(__file__).resolve().parents[1] / "Comfly.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        official_classes = {
+            "Comfly_gpt_image_2_official",
+            "Comfly_gpt_image_2_official_ratio",
+            "Comfly_gpt_image_2_official_ratio_stable",
+        }
+
+        checked = set()
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef) or node.name not in official_classes:
+                continue
+            methods = {
+                child.name: child
+                for child in node.body
+                if isinstance(child, ast.FunctionDef)
+            }
+            async_method = methods["_async_official"]
+            async_calls = [
+                child
+                for child in ast.walk(async_method)
+                if isinstance(child, ast.Call)
+            ]
+            self.assertTrue(
+                any(
+                    isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "make_request_with_retry"
+                    for call in async_calls
+                ),
+                node.name,
+            )
+
+            for method_name in ("_decode_b64_url_one", "_items_to_tensors"):
+                method = methods[method_name]
+                self.assertNotIn(
+                    "max_retries",
+                    [argument.arg for argument in method.args.args],
+                    f"{node.name}.{method_name}",
+                )
+                self.assertTrue(
+                    any(
+                        isinstance(child, ast.Name)
+                        and child.id == "RESULT_DOWNLOAD_ATTEMPTS"
+                        for child in ast.walk(method)
+                    ),
+                    f"{node.name}.{method_name}",
+                )
+            checked.add(node.name)
+
+        self.assertEqual(checked, official_classes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_t8star_http.py
+++ b/tests/test_t8star_http.py
@@ -1,0 +1,304 @@
+import unittest
+from unittest import mock
+
+import requests
+
+from t8star_http import (
+    T8STAR_RETRY_DELAYS,
+    create_alternating_route_session,
+    create_t8star_session,
+    safe_chat_post,
+    safe_get_content,
+    safe_upload_post,
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, chunks=(), content=b""):
+        self.status_code = status_code
+        self.headers = {}
+        self.chunks = chunks
+        self._content = content
+        self.closed = False
+
+    @property
+    def content(self):
+        if isinstance(self._content, Exception):
+            raise self._content
+        return self._content
+
+    def close(self):
+        self.closed = True
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"HTTP {self.status_code}", response=self
+            )
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        for chunk in self.chunks:
+            if isinstance(chunk, Exception):
+                raise chunk
+            yield chunk
+
+
+class FakeSession:
+    outcomes = []
+    calls = []
+
+    def __init__(self):
+        self.trust_env = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def request(self, method, url, **kwargs):
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "trust_env": self.trust_env,
+                "kwargs": kwargs,
+            }
+        )
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    def post(self, url, **kwargs):
+        return self.request("POST", url, **kwargs)
+
+
+class T8StarSessionTests(unittest.TestCase):
+    def setUp(self):
+        FakeSession.outcomes = []
+        FakeSession.calls = []
+        self.session_patch = mock.patch.object(requests, "Session", FakeSession)
+        self.sleep_patch = mock.patch("time.sleep")
+        self.sleep = self.sleep_patch.start()
+        self.session_patch.start()
+
+    def tearDown(self):
+        self.session_patch.stop()
+        self.sleep_patch.stop()
+
+    def test_first_direct_attempt_can_succeed(self):
+        FakeSession.outcomes = [FakeResponse(200)]
+
+        response = create_t8star_session().post(
+            "https://ai.t8star.org/v1/images/edits?async=true",
+            timeout=60,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls], [False]
+        )
+        self.sleep.assert_not_called()
+
+    def test_caller_owned_retry_count_maps_one_to_one_to_routes(self):
+        sessions = [
+            create_alternating_route_session(attempt)
+            for attempt in range(5)
+        ]
+
+        self.assertEqual(
+            [session.trust_env for session in sessions],
+            [False, True, False, True, False],
+        )
+
+    def test_network_failure_falls_back_to_proxy(self):
+        FakeSession.outcomes = [
+            requests.exceptions.SSLError("direct failed"),
+            FakeResponse(200),
+        ]
+
+        create_t8star_session().get("https://ai.t8star.org/v1/tasks/1")
+
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls], [False, True]
+        )
+        self.sleep.assert_called_once_with(T8STAR_RETRY_DELAYS[0])
+
+    def test_get_failures_use_direct_proxy_direct_proxy_then_raise(self):
+        failures = [
+            requests.exceptions.ConnectTimeout("direct 1"),
+            requests.exceptions.ProxyError("proxy 1"),
+            requests.exceptions.ReadTimeout("direct 2"),
+            requests.exceptions.SSLError("proxy 2"),
+        ]
+        FakeSession.outcomes = list(failures)
+
+        with mock.patch("builtins.print") as print_mock:
+            with self.assertRaises(requests.exceptions.SSLError) as raised:
+                create_t8star_session().get(
+                    "https://ai.t8star.org/v1/images/edits?signature=secret"
+                )
+
+        self.assertIs(raised.exception, failures[-1])
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls],
+            [False, True, False, True],
+        )
+        self.assertEqual(self.sleep.call_count, 3)
+        self.assertEqual(
+            [call.args[0] for call in self.sleep.call_args_list],
+            list(T8STAR_RETRY_DELAYS),
+        )
+        logged = " ".join(
+            " ".join(str(argument) for argument in call.args)
+            for call in print_mock.call_args_list
+        )
+        self.assertNotIn("signature=secret", logged)
+
+    def test_retryable_http_status_uses_next_route(self):
+        FakeSession.outcomes = [FakeResponse(503), FakeResponse(200)]
+
+        response = create_t8star_session().get(
+            "https://ai.t8star.org/v1/tasks/1"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls], [False, True]
+        )
+
+    def test_final_http_status_wins_over_an_earlier_transport_error(self):
+        FakeSession.outcomes = [
+            requests.exceptions.SSLError("direct failed"),
+            FakeResponse(503),
+            FakeResponse(503),
+            FakeResponse(503),
+        ]
+
+        response = create_t8star_session().get(
+            "https://ai.t8star.org/v1/tasks/1"
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls],
+            [False, True, False, True],
+        )
+
+    def test_business_4xx_is_not_retried(self):
+        FakeSession.outcomes = [FakeResponse(401)]
+
+        response = create_t8star_session().post(
+            "https://ai.t8star.org/v1/images/generations"
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(len(FakeSession.calls), 1)
+
+    def test_paid_post_transport_failure_is_not_retried(self):
+        failure = requests.exceptions.ConnectTimeout("ambiguous submit")
+        FakeSession.outcomes = [failure]
+
+        with self.assertRaises(requests.exceptions.ConnectTimeout):
+            create_t8star_session().post(
+                "https://ai.t8star.org/v1/images/generations"
+            )
+
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls], [False]
+        )
+        self.sleep.assert_not_called()
+
+    def test_http_500_is_not_retried(self):
+        FakeSession.outcomes = [FakeResponse(500)]
+
+        response = create_t8star_session().get(
+            "https://ai.t8star.org/v1/tasks/1"
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(len(FakeSession.calls), 1)
+
+    def test_tls_eof_while_reading_body_restarts_on_next_route(self):
+        FakeSession.outcomes = [
+            FakeResponse(
+                200,
+                (
+                    b"partial",
+                    requests.exceptions.SSLError("TLS EOF"),
+                ),
+            ),
+            FakeResponse(200, (b"complete", b"-body")),
+        ]
+
+        body = safe_get_content("https://cdn.example.com/result.bin")
+
+        self.assertEqual(body, b"complete-body")
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls],
+            [False, True],
+        )
+
+    def test_explicit_safe_upload_retries_ssl_eof(self):
+        FakeSession.outcomes = [
+            requests.exceptions.SSLError("TLS EOF"),
+            FakeResponse(200),
+        ]
+
+        response = safe_upload_post(
+            "https://ai.t8star.org/v1/files",
+            files={"file": ("x.bin", b"data")},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls],
+            [False, True],
+        )
+
+    def test_explicit_chat_retries_transport_and_temporary_status(self):
+        temporary = FakeResponse(503)
+        FakeSession.outcomes = [
+            requests.exceptions.SSLError("TLS EOF"),
+            temporary,
+            FakeResponse(200),
+        ]
+
+        response = safe_chat_post(
+            "https://ai.t8star.org/v1/chat/completions",
+            json={"model": "test"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls],
+            [False, True, False],
+        )
+        self.assertEqual(
+            [call.args[0] for call in self.sleep.call_args_list], [1, 5]
+        )
+        self.assertTrue(temporary.closed)
+
+    def test_streaming_chat_retries_tls_eof_while_buffering(self):
+        interrupted = FakeResponse(
+            200, content=requests.exceptions.SSLError("TLS EOF")
+        )
+        success = FakeResponse(200, content=b"data: complete\n\n")
+        FakeSession.outcomes = [interrupted, success]
+
+        response = safe_chat_post(
+            "https://ai.t8star.org/v1/chat/completions", stream=True
+        )
+
+        self.assertIs(response, success)
+        self.assertTrue(interrupted.closed)
+        self.assertEqual(
+            [call["trust_env"] for call in FakeSession.calls], [False, True]
+        )
+        self.sleep.assert_called_once_with(1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add shared route-aware HTTP retry helpers
- harden chat/API reads and streamed media downloads against transient failures
- retry direct → proxy → direct → proxy with 1s, 5s, and 10s delays
- retry network/SSL EOF failures and HTTP 429/502/503/504 only
- avoid retaining partial streamed downloads between attempts

## Why

Transient connection resets, incomplete streams, TLS EOF errors, and gateway failures can interrupt API and media operations. These changes make retryable operations recover consistently without retrying permanent business errors.

## Validation

- 24 focused retry and download tests passed
- Python compilation checks passed
- verified partial download cleanup and full four-route fallback
- verified HTTP 500 and permanent 4xx responses are not retried
